### PR TITLE
Tweaks/Improvements

### DIFF
--- a/include/pietendo/ctr/es/Ticket.h
+++ b/include/pietendo/ctr/es/Ticket.h
@@ -49,6 +49,8 @@ public:
 	uint16_t ticket_version;
 	byte_t license_type;
 	byte_t key_id;
+	// property mask flags
+	bool preinstall_flag;
 	// reserved region data
 	uint32_t ec_account_id;
 	// lp record

--- a/include/pietendo/es/cert.h
+++ b/include/pietendo/es/cert.h
@@ -17,7 +17,7 @@ enum ESCertPubKeyType : uint32_t
 {
 	ESCertPubKeyType_RSA4096 = 0, /**< RSA 4096 bit key */
 	ESCertPubKeyType_RSA2048 = 1, /**< RSA 2048 bit key */
-	ESCertPubKeyType_ECC233 = 2, /**< ECC 233 bit key */
+	ESCertPubKeyType_ECCB233 = 2, /**< ECC B233 bit key */
 };
 
 	/**
@@ -57,37 +57,37 @@ struct ESCertHeader
 static_assert(sizeof(ESCertHeader) == 72, "ESCertHeader size");
 
 	/**
-	 * @brief Certificate Public Key (RSA2048)
+	 * @brief Certificate Public Key (RSA-2048)
 	 * 
 	 */
 struct ESCertRsa2048PublicKey
 {
-	detail::Rsa2048PublicKey pubKey; /**< RSA2048 Public Key */
+	detail::Rsa2048PublicKey pubKey; /**< RSA-2048 Public Key */
 	detail::Padding<52>      pad;    /**< Padding */
 };
 static_assert(sizeof(ESCertRsa2048PublicKey) == 312, "ESCertRsa2048PublicKey size");
 
 	/**
-	 * @brief Certificate Public Key (RSA4096)
+	 * @brief Certificate Public Key (RSA-4096)
 	 * 
 	 */
 struct ESCertRsa4096PublicKey
 {
-	detail::Rsa4096PublicKey pubKey; /**< RSA4096 Public Key */
+	detail::Rsa4096PublicKey pubKey; /**< RSA-4096 Public Key */
 	detail::Padding<52>      pad;    /**< Padding */
 };
 static_assert(sizeof(ESCertRsa4096PublicKey) == 568, "ESCertRsa4096PublicKey size");
 
 	/**
-	 * @brief Certificate Public Key (ECC233)
+	 * @brief Certificate Public Key (ECC-B233)
 	 * 
 	 */
-struct ESCertEcc233PublicKey
+struct ESCertEccB233PublicKey
 {
-	detail::Ecc233PublicKey pubKey; /**< ECC233 Public Key */
-	detail::Padding<60>     pad;    /**< Padding */
+	detail::EccB233PublicKey pubKey; /**< ECC-B233 Public Key */
+	detail::Padding<60>      pad;    /**< Padding */
 };
-static_assert(sizeof(ESCertEcc233PublicKey) == 120, "ESCertEcc233PublicKey size");
+static_assert(sizeof(ESCertEccB233PublicKey) == 120, "ESCertEccB233PublicKey size");
 
 	/**
 	 * @brief Root Certificate
@@ -95,7 +95,7 @@ static_assert(sizeof(ESCertEcc233PublicKey) == 120, "ESCertEcc233PublicKey size"
 	 */
 struct ESRootCert
 {
-	ESSigRsa4096             sig;  /**< RSA 4096-bit sign of the certificate */
+	ESSigRsa4096             sig;  /**< RSA-4096 sign of the certificate */
 	ESCertHeader             head; /**< Certificate header */
 	ESCertRsa4096PublicKey   body; /**< Certificate body */
 };
@@ -108,7 +108,7 @@ static_assert(sizeof(ESRootCert) == 1280, "ESRootCert size");
 	 */
 struct ESCACert
 {
-	ESSigRsa4096             sig;  /**< RSA 4096-bit sign of the certificate */
+	ESSigRsa4096             sig;  /**< RSA-4096 sign of the certificate */
 	ESCertHeader             head; /**< Certificate header */
 	ESCertRsa2048PublicKey   body; /**< Certificate body */
 };
@@ -120,7 +120,7 @@ static_assert(sizeof(ESCACert) == 1024, "ESCACert size");
 	 */
 struct ESCASignedCert
 {
-	ESSigRsa2048             sig;  /**< RSA 2048-bit sign of the certificate */
+	ESSigRsa2048             sig;  /**< RSA-2048 sign of the certificate */
 	ESCertHeader             head; /**< Certificate header */
 	ESCertRsa2048PublicKey   body; /**< Certificate body */
 };
@@ -133,9 +133,9 @@ static_assert(sizeof(ESCASignedCert) == 768, "ESCASignedCert size");
 	 */
 struct ESDeviceCert
 {
-	ESSigRsa2048             sig;  /**< RSA 2048-bit sign of the certificate */
+	ESSigRsa2048             sig;  /**< RSA-2048 sign of the certificate */
 	ESCertHeader             head; /**< Certificate header */
-	ESCertEcc233PublicKey    body; /**< Certificate body */
+	ESCertEccB233PublicKey   body; /**< Certificate body */
 };
 static_assert(sizeof(ESDeviceCert) == 576, "ESDeviceCert size");
 
@@ -146,9 +146,9 @@ static_assert(sizeof(ESDeviceCert) == 576, "ESDeviceCert size");
 	 */
 struct ESDeviceSignedCert
 {
-	ESSigEcc233              sig;  /**< ECDSA 233-bit sign of the certificate */
+	ESSigEccB233             sig;  /**< ECC-B233 sign of the certificate */
 	ESCertHeader             head; /**< Certificate header */
-	ESCertEcc233PublicKey    body; /**< Certificate body */
+	ESCertEccB233PublicKey   body; /**< Certificate body */
 };
 static_assert(sizeof(ESDeviceSignedCert) == 384, "ESDeviceSignedCert size");
 

--- a/include/pietendo/es/sign.h
+++ b/include/pietendo/es/sign.h
@@ -2,8 +2,8 @@
 	 * @file sign.h
 	 * @brief Declaration of ES Signature structs and data types for the ES library
 	 * @author Jack (jakcron)
-	 * @version 0.1
-	 * @date 2022/06/25
+	 * @version 0.2
+	 * @date 2022/09/22
 	 **/
 #pragma once
 #include <pietendo/es/types.h>
@@ -15,13 +15,13 @@ namespace pie { namespace es {
      */
 enum ESSigType : uint32_t
 {
-    ESSigType_RSA4096_SHA1   = 0x00010000, /**< __RSA4096-PKCS1-SHA1__ signature */
-    ESSigType_RSA2048_SHA1   = 0x00010001, /**< __RSA2048-PKCS1-SHA1__ signature */
-    ESSigType_ECC_SHA1       = 0x00010002, /**< __ECDSA233-SHA1__ signature */
-    ESSigType_RSA4096_SHA256 = 0x00010003, /**< __RSA4096-PKCS1-SHA2-256__ signature */
-    ESSigType_RSA2048_SHA256 = 0x00010004, /**< __RSA2048-PKCS1-SHA2-256__ signature (note that Switch Ticket has this word swapped) */
-    ESSigType_ECC_SHA256     = 0x00010005, /**< __ECDSA233-SHA256__ signature */
-    ESSigType_HMAC_SHA1      = 0x00010006, /**< __HMAC-SHA1__ signature (This uses the ESSigRsa2048 sign structure, with spare sig space padded with nulls) */
+    ESSigType_RSA4096_SHA1    = 0x00010000, /**< __RSA-4096-PKCS1-SHA1__ signature */
+    ESSigType_RSA2048_SHA1    = 0x00010001, /**< __RSA-2048-PKCS1-SHA1__ signature */
+    ESSigType_ECCB233_SHA1    = 0x00010002, /**< __ECC-B233-ECDSA-SHA1__ signature */
+    ESSigType_RSA4096_SHA2256 = 0x00010003, /**< __RSA-4096-PKCS1-SHA2-256__ signature */
+    ESSigType_RSA2048_SHA2256 = 0x00010004, /**< __RSA-2048-PKCS1-SHA2-256__ signature */
+    ESSigType_ECCB233_SHA2256 = 0x00010005, /**< __ECC-B233-ECDSA-SHA2-256__ signature */
+    ESSigType_HMAC_SHA1       = 0x00010006, /**< __HMAC-SHA1__ signature (This uses the ESSigRsa2048 sign structure, with spare sig space padded with nulls) */
 };
 
 	/**
@@ -44,7 +44,7 @@ using ESIssuer = tc::bn::string<64>;
 #pragma pack(push,4)
 
 	/**
-	 * @brief ES Signature (RSA2048)
+	 * @brief ES Signature (RSA-2048)
 	 * 
 	 */
 struct ESSigRsa2048
@@ -57,7 +57,22 @@ struct ESSigRsa2048
 static_assert(sizeof(ESSigRsa2048) == 384, "ESSigRsa2048 size");
 
 	/**
-	 * @brief ES Signature (RSA4096)
+	 * @brief ES Signature (RSA-2048) (Little Endian variant)
+	 * @details This is used for Nintendo Switch Tickets
+	 * 
+	 */
+struct ESSigRsa2048_LE
+{
+	tc::bn::le32<ESSigType>    sigType; /**< Signature type */
+	detail::Rsa2048Sig         sig;     /**< Signature data */
+	detail::Padding<60>        pad;     /**< Padding */
+	ESIssuer                   issuer;  /**< Signature issuer */
+};
+static_assert(sizeof(ESSigRsa2048_LE) == 384, "ESSigRsa2048_LE size");
+
+
+	/**
+	 * @brief ES Signature (RSA-4096)
 	 * 
 	 */
 struct ESSigRsa4096
@@ -70,17 +85,17 @@ struct ESSigRsa4096
 static_assert(sizeof(ESSigRsa4096) == 640, "ESSigRsa4096 size");
 
 	/**
-	 * @brief ES Signature (ECC233)
+	 * @brief ES Signature (ECC-B233)
 	 * 
 	 */
-struct ESSigEcc233
+struct ESSigEccB233
 {
 	tc::bn::be32<ESSigType>    sigType; /**< Signature type */
-	detail::Ecc233Sig          sig;     /**< Signature data */
+	detail::EccB233Sig         sig;     /**< Signature data */
 	detail::Padding<64>        pad;     /**< Padding */
 	ESIssuer                   issuer;  /**< Signature issuer */
 };
-static_assert(sizeof(ESSigEcc233) == 192, "ESSigEcc233 size");
+static_assert(sizeof(ESSigEccB233) == 192, "ESSigEccB233 size");
 
 #pragma pack(pop)
 

--- a/include/pietendo/es/sign.h
+++ b/include/pietendo/es/sign.h
@@ -21,7 +21,7 @@ enum ESSigType : uint32_t
     ESSigType_RSA4096_SHA256 = 0x00010003, /**< __RSA4096-PKCS1-SHA2-256__ signature */
     ESSigType_RSA2048_SHA256 = 0x00010004, /**< __RSA2048-PKCS1-SHA2-256__ signature (note that Switch Ticket has this word swapped) */
     ESSigType_ECC_SHA256     = 0x00010005, /**< __ECDSA233-SHA256__ signature */
-    ESSigType_HMAC_SHA1      = 0x00010006, /**< __HMAC-SHA1__ signature */
+    ESSigType_HMAC_SHA1      = 0x00010006, /**< __HMAC-SHA1__ signature (This uses the ESSigRsa2048 sign structure, with spare sig space padded with nulls) */
 };
 
 	/**

--- a/include/pietendo/es/ticket.h
+++ b/include/pietendo/es/ticket.h
@@ -67,7 +67,7 @@ enum ESItemType : uint32_t
 	 * @brief ES PropertyMask flags
 	 * 
 	 */
-enum class ESPropertyMaskFlag : uint16_t
+enum ESPropertyMaskFlag : uint16_t
 {
 	ESPropertyMaskFlag_PRE_INSTALL = 0x1, /**< Pre-install */
 	ESPropertyMaskFlag_SHARED_TITLE = 0x2, /**< Shared title */

--- a/include/pietendo/es/ticket.h
+++ b/include/pietendo/es/ticket.h
@@ -275,7 +275,7 @@ struct ESV2Ticket
 	uint8_t                 licenseType;        /**< License type */
 	uint8_t                 keyId;              /**< Common key ID */
 	tc::bn::le16<uint16_t>  propertyMask;       /**< 16-bit property mask */
-	ESV2TicketReserved      reservedRegion;     /**< probably the accessTitleId & mask */
+	ESV2TicketReserved      reserved;           /**< Reserved (probably the accessTitleId & mask and later scrapped) */
 	tc::bn::le64<uint64_t>  ticketId;           /**< Unique 64bit ticket ID */
 	tc::bn::le64<uint64_t>  deviceId;           /**< Unique 64bit device ID */
 	ESRightsId              rightsId;           /**< Unique 128bit rights ID */

--- a/include/pietendo/es/ticket.h
+++ b/include/pietendo/es/ticket.h
@@ -92,10 +92,10 @@ enum ESV1SectionHeaderFlag : uint16_t
 	 * * __COMMON__ - TitleKey is encrypted using AES128-CBC with the CommonKey (as indicated in the ticket header).
 	 * * __PERSONALIZED__ - Same as __COMMON__ but the encrypted payload is further encrypted using RSA2048-OAEP, with the device specific RSA key.
 	 */
-enum ESV2TitleKekType : byte_t
+enum ESV2TitleKeyType : byte_t
 {
-	ESV2TitleKekType_COMMON = 0, /**< Common `AES128-CBC(TitleKey)` */
-	ESV2TitleKekType_PERSONALIZED = 1, /**< Personalized `RSA2048-OAEP(AES128-CBC(TitleKey))` */
+	ESV2TitleKeyType_COMMON = 0, /**< Common `AES128-CBC(TitleKey)` */
+	ESV2TitleKeyType_PERSONALIZED = 1, /**< Personalized `RSA2048-OAEP(AES128-CBC(TitleKey))` */
 };
 
 #pragma pack(push, 4)
@@ -270,7 +270,7 @@ struct ESV2Ticket
 	ESSigRsa2048            sig;                /**< RSA 2048-bit sign of the ticket */
 	ESV2TitleKey            titleKey;           /**< Published title key */
 	uint8_t                 version;            /**< Ticket data structure version number */
-	uint8_t                 keyType;            /**< Title key encryption key type */
+	uint8_t                 titleKeyType;       /**< Title key encryption type */
 	tc::bn::le16<uint16_t>  ticketVersion;      /**< 16-bit ticket version */
 	uint8_t                 licenseType;        /**< License type */
 	uint8_t                 keyId;              /**< Common key ID */

--- a/include/pietendo/es/ticket.h
+++ b/include/pietendo/es/ticket.h
@@ -135,7 +135,7 @@ struct ESTicket
 	using ESLimitedPlayArray = std::array<ESLimitedPlayEntry, 8>;
 
 	ESSigRsa2048              sig;               /**< RSA 2048-bit sign of the ticket */
-	detail::Ecc233PublicKey   serverPubKey;      /**< Ticketing server public key */
+	detail::EccB233PublicKey  serverPubKey;      /**< Ticketing server public key */
 	uint8_t                   version;           /**< Ticket data structure version number */
 	uint8_t                   caCrlVersion;      /**< CA CRL version number */
 	uint8_t                   signerCrlVersion;  /**< Signer CRL version number */

--- a/include/pietendo/es/ticket.h
+++ b/include/pietendo/es/ticket.h
@@ -2,8 +2,8 @@
 	 * @file ticket.h
 	 * @brief Declaration of Ticket structs and enums for the ES library.
 	 * @author Jack (jakcron)
-	 * @version 0.1
-	 * @date 2022/06/25
+	 * @version 0.2
+	 * @date 2022/09/22
 	 **/
 #pragma once
 #include <pietendo/es/sign.h>

--- a/include/pietendo/es/ticket.h
+++ b/include/pietendo/es/ticket.h
@@ -267,7 +267,7 @@ struct ESV2Ticket
 	using ESRightsId = std::array<byte_t, 16>;
 	using ESV2TicketReserved = std::array<byte_t, 8>;
 
-	ESSigRsa2048            sig;                /**< RSA 2048-bit sign of the ticket */
+	ESSigRsa2048_LE         sig;                /**< RSA 2048-bit sign of the ticket */
 	ESV2TitleKey            titleKey;           /**< Published title key */
 	uint8_t                 version;            /**< Ticket data structure version number */
 	uint8_t                 titleKeyType;       /**< Title key encryption type */

--- a/include/pietendo/es/tmd.h
+++ b/include/pietendo/es/tmd.h
@@ -16,13 +16,13 @@ namespace pie { namespace es {
 	 */
 enum ESTitleType : uint32_t
 {
-	ESTitleType_NC_TITLE   = 0x1, /**< NetCard Title - End-of-life (bit0) */
-	ESTitleType_NG_TITLE   = 0x2, /**< NextGen Title - Wii/NDEV (bit1) */
-	ESTitleType_DS_TITLE   = 0x4, /**< DS Title - TWL/DSi (bit2) */
-	ESTitleType_DATA       = 0x8, /**< Data Title (bit3) */
-	ESTitleType_CT_TITLE   = 0x40, /**< CTR Title - CTR/3DS (bit6) */
-	ESTitleType_GVM_TITLE  = 0x80, /**< GVM = ? (bit7, from BroadOn libraries) */
-	ESTitleType_CAFE_TITLE = 0x100, /**< Cafe Title - WiiU (bit8, from WiiU sdk) */
+	ESTitleType_NC_TITLE   = (1 << 0), /**< NetCard Title - NetCard, End-of-life (bit0) */
+	ESTitleType_NG_TITLE   = (1 << 1), /**< NextGen Title - Wii/NDEV (bit1) */
+	ESTitleType_DS_TITLE   = (1 << 2), /**< DS Title - TWL/DSi (bit2) */
+	ESTitleType_DATA       = (1 << 3), /**< Data Title (bit3) */
+	ESTitleType_CT_TITLE   = (1 << 6), /**< CTR Title - CTR/3DS (bit6) */
+	ESTitleType_GVM_TITLE  = (1 << 7), /**< GVM Title - ??? (bit7) */
+	ESTitleType_CAFE_TITLE = (1 << 8), /**< Cafe Title - WiiU (bit8) */
 };
 
 	/**
@@ -31,16 +31,33 @@ enum ESTitleType : uint32_t
 	 * These flags describe properties about a particular content.
 	 * 
 	 * Support flags vary from platform to platform.
+	 * 
+	 * RVL (Wii) supported flags:
+	 * * ESContentType_ENCRYPTED
+	 * * ESContentType_OPTIONAL
+	 * * ESContentType_SHARED
+	 * 
+	 * TWL (DSi) supported flags:
+	 * * ESContentType_ENCRYPTED
+	 * 
+	 * CTR (3DS) supported flags:
+	 * * ESContentType_ENCRYPTED
+	 * * ESContentType_OPTIONAL
+	 * 
+	 * CAFE (WiiU) supported flags:
+	 * * ESContentType_ENCRYPTED
+	 * * ESContentType_HASHED
+	 * * ESContentType_SHA1_HASH
+	 * * ESContentType_OPTIONAL
 	 */
 enum ESContentType : uint16_t
 {
-	ESContentType_ENCRYPTED = 0x1, /**< Encrypted - (bit0, from broadOn & b4) */
-	ESContentType_DISC      = 0x2, /**< Disc - (bit1, from broadOn & b4)) */
-	ESContentType_HASHED    = 0x2, /**< Hashed - (bit1, from b4) */
-	ESContentType_CFM       = 0x4, /**< CFM - (bit2, from broadOn & b4) */
-	ESContentType_SHA1_HASH = 0x2000, /**< SHA1 Hash - (bit13, from b4 (wiiu sdk) */
-	ESContentType_OPTIONAL  = 0x4000, /**< Optional - (bit14, from broadOn & b4) */
-	ESContentType_SHARED    = 0x8000, /**< Shared - (bit15,from broadOn & b4) */
+	ESContentType_ENCRYPTED = (1 <<  0), /**< Encrypted - (bit0) */
+	ESContentType_HASHED    = (1 <<  1), /**< Hashed - (bit1) */
+	ESContentType_CFM       = (1 <<  2), /**< CFM - (bit2) */
+	ESContentType_SHA1_HASH = (1 << 13), /**< SHA1 Hash - (bit13) */
+	ESContentType_OPTIONAL  = (1 << 14), /**< Optional - (bit14) */
+	ESContentType_SHARED    = (1 << 15), /**< Shared - (bit15) */
 };
 
 	/**
@@ -115,6 +132,7 @@ struct ESTitleMetaHeader
 	uint8_t                   version;            /**< TMD version number */
 	uint8_t                   caCrlVersion;       /**< CA CRL version number */
 	uint8_t                   signerCrlVersion;   /**< Signer CRL version number */
+	uint8_t                   customFlag;         /**< 1-byte custom flag. Used only in WiiU vWii TMDs (set to 1). */
 	tc::bn::be64<uint64_t>    sysVersion;         /**< System software version number */
 	tc::bn::be64<uint64_t>    titleId;            /**< 64-bit title id */
 	tc::bn::be32<ESTitleType> type;               /**< 32-bit title type */

--- a/include/pietendo/es/tmd.h
+++ b/include/pietendo/es/tmd.h
@@ -2,8 +2,8 @@
 	 * @file tmd.h
 	 * @brief Declaration of TitleMeta structs and enums for the ES library.
 	 * @author Jack (jakcron)
-	 * @version 0.1
-	 * @date 2022/06/25
+	 * @version 0.2
+	 * @date 2022/09/22
 	 **/
 #pragma once
 #include <pietendo/es/sign.h>

--- a/include/pietendo/es/tmd.h
+++ b/include/pietendo/es/tmd.h
@@ -34,6 +34,7 @@ enum ESTitleType : uint32_t
 	 * 
 	 * RVL (Wii) supported flags:
 	 * * ESContentType_ENCRYPTED
+	 * * ESContentType_HASHED
 	 * * ESContentType_OPTIONAL
 	 * * ESContentType_SHARED
 	 * 
@@ -53,11 +54,11 @@ enum ESTitleType : uint32_t
 enum ESContentType : uint16_t
 {
 	ESContentType_ENCRYPTED = (1 <<  0), /**< Encrypted - (bit0) */
-	ESContentType_HASHED    = (1 <<  1), /**< Hashed - (bit1) */
-	ESContentType_CFM       = (1 <<  2), /**< CFM - (bit2) */
+	ESContentType_HASHED    = (1 <<  1), /**< Hashed (Previously this was called DISC, because only RVL discs had the hashed data) - (bit1) */
+	ESContentType_CFM       = (1 <<  2), /**< Content File Metadata - (bit2) */
 	ESContentType_SHA1_HASH = (1 << 13), /**< SHA1 Hash - (bit13) */
-	ESContentType_OPTIONAL  = (1 << 14), /**< Optional - (bit14) */
-	ESContentType_SHARED    = (1 << 15), /**< Shared - (bit15) */
+	ESContentType_OPTIONAL  = (1 << 14), /**< Optional Content - (bit14) */
+	ESContentType_SHARED    = (1 << 15), /**< Shared Content - (bit15) */
 };
 
 	/**

--- a/include/pietendo/es/tmd.h
+++ b/include/pietendo/es/tmd.h
@@ -30,7 +30,7 @@ enum ESTitleType : uint32_t
 	 * @details
 	 * These flags describe properties about a particular content.
 	 * 
-	 * Support flags vary from platform to platform.
+	 * Supported flags vary from platform to platform.
 	 * 
 	 * RVL (Wii) supported flags:
 	 * * ESContentType_ENCRYPTED
@@ -187,8 +187,8 @@ static_assert(sizeof(ESTitleMeta) == 484, "ESTitleMeta size");
 	 * @brief TitleMetaData (format v1)
 	 * 
 	 * Platforms that use this version:
-	 * * Nintendo WiiU (CAFE)
 	 * * Nintendo 3DS (CTR)
+	 * * Nintendo WiiU (CAFE)
 	 */
 struct ESV1TitleMeta
 {

--- a/include/pietendo/es/tmd.h
+++ b/include/pietendo/es/tmd.h
@@ -11,18 +11,22 @@
 namespace pie { namespace es {
 
 	/**
-	 * @brief ES title type
+	 * @brief ES title type (bitmask)
+	 * @details
 	 * 
+	 * These flags describe the type of title, however these aren't always set.
 	 */
 enum ESTitleType : uint32_t
 {
-	//ESTitleType_NC_TITLE   = (1 << 0), /**< NetCard Title - NetCard, End-of-life (bit0) */
-	//ESTitleType_NG_TITLE   = (1 << 1), /**< NextGen Title - Wii/NDEV (bit1) */
-	//ESTitleType_DS_TITLE   = (1 << 2), /**< DS Title - TWL/DSi (bit2) */
-	//ESTitleType_DATA       = (1 << 3), /**< Data Title (bit3) */
-	//ESTitleType_CT_TITLE   = (1 << 6), /**< CTR Title - CTR/3DS (bit6) */
-	//ESTitleType_GVM_TITLE  = (1 << 7), /**< GVM Title - Graphics Virtual Machine (bit7) */
-	//ESTitleType_CAFE_TITLE = (1 << 8), /**< Cafe Title - WiiU (bit8) */
+	ESTitleType_NC_TITLE   = 0, /**< NC Title - NetCard */
+	ESTitleType_NG_TITLE   = 1, /**< NG Title - NextGen/NDEV/RVL/Wii */
+	ESTitleType_DS_TITLE   = 2, /**< DS Title */
+	ESTitleType_STREAM     = 4, /**< Stream */
+	ESTitleType_DATA       = 8, /**< Data */
+	ESTitleType_CACHE_DATA = 0x10, /**< Cache Data */
+	ESTitleType_CT_TITLE   = 0x40, /**< CTR Title - CTR/3DS */
+	ESTitleType_GVM_TITLE  = 0x80, /**< GVM Title - Graphics Virtual Machine */
+	ESTitleType_CAFE_TITLE = 0x100, /**< CAFE Title - CAFE/WiiU */
 };
 
 	/**

--- a/include/pietendo/es/tmd.h
+++ b/include/pietendo/es/tmd.h
@@ -16,13 +16,13 @@ namespace pie { namespace es {
 	 */
 enum ESTitleType : uint32_t
 {
-	ESTitleType_NC_TITLE   = (1 << 0), /**< NetCard Title - NetCard, End-of-life (bit0) */
-	ESTitleType_NG_TITLE   = (1 << 1), /**< NextGen Title - Wii/NDEV (bit1) */
-	ESTitleType_DS_TITLE   = (1 << 2), /**< DS Title - TWL/DSi (bit2) */
-	ESTitleType_DATA       = (1 << 3), /**< Data Title (bit3) */
-	ESTitleType_CT_TITLE   = (1 << 6), /**< CTR Title - CTR/3DS (bit6) */
-	ESTitleType_GVM_TITLE  = (1 << 7), /**< GVM Title - ??? (bit7) */
-	ESTitleType_CAFE_TITLE = (1 << 8), /**< Cafe Title - WiiU (bit8) */
+	//ESTitleType_NC_TITLE   = (1 << 0), /**< NetCard Title - NetCard, End-of-life (bit0) */
+	//ESTitleType_NG_TITLE   = (1 << 1), /**< NextGen Title - Wii/NDEV (bit1) */
+	//ESTitleType_DS_TITLE   = (1 << 2), /**< DS Title - TWL/DSi (bit2) */
+	//ESTitleType_DATA       = (1 << 3), /**< Data Title (bit3) */
+	//ESTitleType_CT_TITLE   = (1 << 6), /**< CTR Title - CTR/3DS (bit6) */
+	//ESTitleType_GVM_TITLE  = (1 << 7), /**< GVM Title - Graphics Virtual Machine (bit7) */
+	//ESTitleType_CAFE_TITLE = (1 << 8), /**< Cafe Title - WiiU (bit8) */
 };
 
 	/**

--- a/include/pietendo/es/tmd.h
+++ b/include/pietendo/es/tmd.h
@@ -137,7 +137,7 @@ struct ESTitleMetaHeader
 	uint8_t                   version;            /**< TMD version number */
 	uint8_t                   caCrlVersion;       /**< CA CRL version number */
 	uint8_t                   signerCrlVersion;   /**< Signer CRL version number */
-	uint8_t                   customFlag;         /**< 1-byte custom flag. Used only in WiiU vWii TMDs (set to 1). */
+	uint8_t                   platformVersion;    /**< Platform version number. Used only in WiiU to differentiate between Wii and vWii TMDs (set to 1 for vWii). */
 	tc::bn::be64<uint64_t>    sysVersion;         /**< System software version number */
 	tc::bn::be64<uint64_t>    titleId;            /**< 64-bit title id */
 	tc::bn::be32<ESTitleType> type;               /**< 32-bit title type */

--- a/include/pietendo/es/types.h
+++ b/include/pietendo/es/types.h
@@ -2,8 +2,8 @@
 	 * @file types.h
 	 * @brief Declaration of common structs and data types for the ES library
 	 * @author Jack (jakcron)
-	 * @version 0.1
-	 * @date 2022/06/25
+	 * @version 0.2
+	 * @date 2022/09/22
 	 **/
 #pragma once
 #include <tc/types.h>
@@ -37,9 +37,9 @@ static const size_t kSha1Size = 20;
 using Sha1Hash = std::array<uint8_t, kSha1Size>;
 using Sha1Hmac = std::array<uint8_t, kSha1Size>;
 
-static const size_t kSha256Size = 32;
-using Sha256Hash = std::array<uint8_t, kSha256Size>;
-using Sha256Hmac = std::array<uint8_t, kSha256Size>;
+static const size_t kSha2256Size = 32;
+using Sha2256Hash = std::array<uint8_t, kSha2256Size>;
+using Sha2256Hmac = std::array<uint8_t, kSha2256Size>;
 
 static const size_t kRsaPublicExponentSize = 4;
 using RsaPublicExponent = std::array<uint8_t, kRsaPublicExponentSize>;
@@ -72,19 +72,19 @@ struct Rsa4096PrivateKey
 };
 using Rsa4096Sig = Rsa4096Integer;
 
-static const size_t kEcc233Size = 60;
-using Ecc233Integer = std::array<uint8_t, kEcc233Size / 2>;
-struct Ecc233Point
+static const size_t kEccB233Size = 0x1E; //  = (233 / 8) + ((233 % 8) ? 1 : 0)
+using EccB233Integer = std::array<uint8_t, kEccB233Size>;
+struct EccB233Point
 {
-	Ecc233Integer x;
-	Ecc233Integer y;
+	EccB233Integer x;
+	EccB233Integer y;
 };
-using Ecc233PrivateKey = Ecc233Integer;
-using Ecc233PublicKey = Ecc233Point;
-struct Ecc233Sig
+using EccB233PrivateKey = EccB233Integer;
+using EccB233PublicKey = EccB233Point;
+struct EccB233Sig
 {
-	Ecc233Integer r;
-	Ecc233Integer s;
+	EccB233Integer r;
+	EccB233Integer s;
 };
 
 #pragma pack(pop)

--- a/src/ctr/es/Ticket.cpp
+++ b/src/ctr/es/Ticket.cpp
@@ -143,6 +143,9 @@ pie::ctr::es::TicketDeserialiser::TicketDeserialiser(const std::shared_ptr<tc::i
 	this->license_type = tik->head.licenseType;
 	this->key_id = tik->head.keyId;
 
+	// process property mask
+	this->preinstall_flag = tik->head.propertyMask.unwrap() & pie::es::ESPropertyMaskFlag_PRE_INSTALL;
+
 	// process data from reserved field
 	auto custom_data = (TicketReservedForCtr*)tik->head.reserved.data();
 	this->ec_account_id = custom_data->ec_account_id.unwrap();

--- a/src/hac/GameCardHeader.cpp
+++ b/src/hac/GameCardHeader.cpp
@@ -112,8 +112,8 @@ void pie::hac::GameCardHeader::fromBytes(const byte_t* data, size_t len)
 
 	mRomAreaStartPage = hdr->rom_area_start_page.unwrap();
 	mBackupAreaStartPage = hdr->backup_area_start_page.unwrap();
-	mKekIndex = hdr->key_flag & 7;
-	mTitleKeyDecIndex = (hdr->key_flag >> 4) & 7;
+	mKekIndex = hdr->key_flag & 0xf;
+	mTitleKeyDecIndex = (hdr->key_flag >> 4) & 0xf;
 	mRomSize = hdr->rom_size;
 	mCardHeaderVersion = hdr->card_header_version;
 	for (size_t i = 0; i < hdr->flags.bit_size(); i++)


### PR DESCRIPTION
# Changes
* `ESSigType_HMAC_SHA1` was clarified to use the `ESSigRsa2048` structure
* Fixed `ESPropertyMaskFlag` type: `enum class` -> `enum`
* `ESV2TitleKekType` renamed to `ESV2TitleKeyType`
* Following more research, `ESTitleType` and `ESContentType` were clarified
* Defined TMD field `platformVersion` used by the WiiU to differentiate between Wii and vWii TMDs
* Clarify that ECC-B233 is the curve used for current ES library definitions
* Fixed bug where HAC GameCard fields `KekIndex` and `TitleKeyDecIndex` weren't deserialized properly 