### PR TITLE
Add support for BKTR Encrypted Streams & Fix uninitialised data bug in HierarchicalIntegrityStream

### DIFF
--- a/build/visualstudio/libpietendo/libpietendo.vcxproj
+++ b/build/visualstudio/libpietendo/libpietendo.vcxproj
@@ -187,6 +187,8 @@
     <ClInclude Include="..\..\..\include\pietendo\hac\ApplicationControlPropertyUtil.h" />
     <ClInclude Include="..\..\..\include\pietendo\hac\ApplicationMetaExtendedHeader.h" />
     <ClInclude Include="..\..\..\include\pietendo\hac\AssetHeader.h" />
+    <ClInclude Include="..\..\..\include\pietendo\hac\BKTREncryptedStream.h" />
+    <ClInclude Include="..\..\..\include\pietendo\hac\BKTRSubsectionEncryptedStream.h" />
     <ClInclude Include="..\..\..\include\pietendo\hac\CombinedFsSnapshotGenerator.h" />
     <ClInclude Include="..\..\..\include\pietendo\hac\ContentArchiveHeader.h" />
     <ClInclude Include="..\..\..\include\pietendo\hac\ContentArchiveUtil.h" />
@@ -299,6 +301,8 @@
     <ClCompile Include="..\..\..\src\hac\ApplicationControlPropertyUtil.cpp" />
     <ClCompile Include="..\..\..\src\hac\ApplicationMetaExtendedHeader.cpp" />
     <ClCompile Include="..\..\..\src\hac\AssetHeader.cpp" />
+    <ClCompile Include="..\..\..\src\hac\BKTREncryptedStream.cpp" />
+    <ClCompile Include="..\..\..\src\hac\BKTRSubsectionEncryptedStream.cpp" />
     <ClCompile Include="..\..\..\src\hac\CombinedFsSnapshotGenerator.cpp" />
     <ClCompile Include="..\..\..\src\hac\ContentArchiveHeader.cpp" />
     <ClCompile Include="..\..\..\src\hac\ContentArchiveUtil.cpp" />

--- a/build/visualstudio/libpietendo/libpietendo.vcxproj.filters
+++ b/build/visualstudio/libpietendo/libpietendo.vcxproj.filters
@@ -450,6 +450,12 @@
     <ClInclude Include="..\..\..\include\pietendo\hac\es\TicketBody_V2.h">
       <Filter>Header Files\pietendo\hac\es</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\include\pietendo\hac\BKTREncryptedStream.h">
+      <Filter>Header Files\pietendo\hac</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\include\pietendo\hac\BKTRSubsectionEncryptedStream.h">
+      <Filter>Header Files\pietendo\hac</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\src\ctr\CciFsSnapshotGenerator.cpp">
@@ -688,6 +694,12 @@
     </ClCompile>
     <ClCompile Include="..\..\..\src\hac\es\TicketBody_V2.cpp">
       <Filter>Source Files\hac\es</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\hac\BKTREncryptedStream.cpp">
+      <Filter>Source Files\hac</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\hac\BKTRSubsectionEncryptedStream.cpp">
+      <Filter>Source Files\hac</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/include/pietendo/hac/BKTREncryptedStream.h
+++ b/include/pietendo/hac/BKTREncryptedStream.h
@@ -1,0 +1,184 @@
+	/**
+	 * @file    BKTREncryptedStream.h
+	 * @brief   Declaration of pie::hac::BKTREncryptedStream
+	 * @author  Sam (sagumamugas)
+	 * @version 0.1
+	 * @date    2023/01/10
+	 **/
+#pragma once
+#include <list>
+#include <tc/ByteData.h>
+#include <tc/io/IStream.h>
+#include <tc/crypto/Aes128CtrEncryptor.h>
+
+#include <tc/ArgumentOutOfRangeException.h>
+#include <tc/ObjectDisposedException.h>
+#include <tc/NotSupportedException.h>
+#include <tc/NotImplementedException.h>
+#include <tc/io/IOException.h>
+
+#include <pietendo/hac/define/nca.h>
+
+namespace pie { namespace hac {
+
+	/**
+	 * @class BKTREncryptedStream
+	 * @brief Class for reading from a stream that is encrypted with AES128-CTR-EX (BKTR section in NCA).
+	 * @details This class takes an encrypted IStream, encryption parameters, patch info and IStream to NCA base 
+	 *          and creates an IStream that will transparently decrypt data when reading.
+	 */
+class BKTREncryptedStream : public tc::io::IStream
+{
+public:
+		/**
+		 * @brief This is the data-type for AES128-CTR key used with Aes128CtrEncryptedStream.
+		 * 
+		 */
+	using key_t = std::array<byte_t, tc::crypto::Aes128CtrEncryptor::kKeySize>;
+
+		/**
+		 * @brief This is the data-type for AES128-CTR block counter used with Aes128CtrEncryptedStream.
+		 * 
+		 */
+	using counter_t = std::array<byte_t, tc::crypto::Aes128CtrEncryptor::kBlockSize>;
+
+		/**
+		 * @brief This is the data-type for AES128-CTR data block used with Aes128CtrEncryptedStream.
+		 * 
+		 */
+	using block_t = std::array<byte_t, tc::crypto::Aes128CtrEncryptor::kBlockSize>;
+
+		/**
+		 * @brief Default Constructor
+		 * @post This will create an uninitialized BKTREncryptedStream, it will have to be assigned from a valid BKTREncryptedStream object to be usable.
+		 **/
+	BKTREncryptedStream();
+
+		/** 
+		 * @brief Create BKTREncryptedStream
+		 * 
+		 * @param[in] stream     The base IStream object which this stream will decrypt data from.
+		 * @param[in] key        AES128 Encryption Key. See @ref key_t.
+		 * @param[in] counter    AES128-CTR Counter relative to offset 0x0 of the base stream. See @ref counter_t.
+		 * @param[in] patch_info BKTR section
+		 * @param[in] baseStream IStream to base NCA
+		 * 
+		 * @pre The sub stream must be a subset of the base stream.
+		 * @pre A stream must support seeking for @ref seek to work. 
+		 * 
+		 * @throw tc::ArgumentNullException @p stream @p baseStream is a @p nullptr.
+		 * @throw tc::NotSupportedException The base stream does not support seeking or reading.
+		 **/
+	BKTREncryptedStream(const std::shared_ptr<tc::io::IStream>& stream, const key_t& key, const counter_t& counter, const pie::hac::sContentArchiveFsHeaderPatchInfo& patch_info, const std::shared_ptr<tc::io::IStream>& baseStream);
+
+		/**
+		 * @brief Indicates whether the current stream supports reading.
+		 **/ 
+	bool canRead() const;
+
+		/**
+		 * @brief Indicates whether the current stream supports writing.
+		 **/
+	bool canWrite() const;
+
+		/**
+		 * @brief Indicates whether the current stream supports seeking.
+		 **/
+	bool canSeek() const;
+
+		/**
+		 * @brief Gets the length in bytes of the stream.
+		 **/
+	int64_t length();
+
+		/** 
+		 * @brief Gets the position within the current stream. 
+		 * 
+		 * @return This is returns the current position within the stream.
+		 **/
+	int64_t position();
+
+		/**
+		 * @brief Reads a sequence of bytes from the current stream and advances the position within the stream by the number of bytes read.
+		 * 
+		 * @param[out] ptr Pointer to an array of bytes. When this method returns, @p ptr contains the specified byte array with the values between 0 and (@p count - 1) replaced by the bytes read from the current source.
+		 * @param[in] count The maximum number of bytes to be read from the current stream.
+		 * 
+		 * @return The total number of bytes read into @p ptr. This can be less than the number of bytes requested if that many bytes are not currently available, or zero (0) if the end of the stream has been reached.
+		 * 
+		 * @pre A stream must support reading for @ref read to work. 
+		 * @note Use @ref canRead to determine if this stream supports reading.
+		 * @note Exceptions thrown by the base stream are not altered/intercepted, refer to that module's documentation for those exceptions.
+		 * 
+		 * @throw tc::ArgumentOutOfRangeException @p count exceeds the length of readable data in the sub stream.
+		 * @throw tc::ObjectDisposedException Methods were called after the stream was closed.
+		 **/
+	size_t read(byte_t* ptr, size_t count);
+
+		/**
+		 * @brief Writes a sequence of bytes to the current stream and advances the current position within this stream by the number of bytes written. @ref write is not implemented for @ref BKTREncryptedStream.
+		 * @throw tc::NotImplementedException @ref write is not implemented for @ref BKTREncryptedStream.
+		 * @throw tc::ObjectDisposedException Methods were called after the stream was closed.
+		 **/
+	size_t write(const byte_t* ptr, size_t count);
+
+		/**
+		 * @brief Sets the position within the current stream.
+		 * 
+		 * @param[in] offset A byte offset relative to the origin parameter.
+		 * @param[in] origin A value of type @ref tc::io::SeekOrigin indicating the reference point used to obtain the new position.
+		 * 
+		 * @return The new position within the current stream.
+		 * 
+		 * @pre A stream must support seeking for @ref seek to work. 
+		 * @note Use @ref canSeek to determine if this stream supports seeking.
+		 * @note Exceptions thrown by the base stream are not altered/intercepted, refer to that module's documentation for those exceptions.
+		 * 
+		 * @throw tc::ArgumentOutOfRangeException @p origin contains an invalid value.
+		 * @throw tc::ObjectDisposedException Methods were called after the stream was closed.
+		 **/
+	int64_t seek(int64_t offset, tc::io::SeekOrigin origin);
+
+		/**
+		 * @brief Sets the length of the current stream. This is not implemented for @ref BKTREncryptedStream.
+		 * @throw tc::NotImplementedException @ref setLength is not implemented for @ref BKTREncryptedStream.
+		 * @throw tc::ObjectDisposedException Methods were called after the stream was closed.
+		 **/
+	void setLength(int64_t length);
+
+		/**
+		 * @brief Clears all buffers for this and the base stream and causes any buffered data to be written to the underlying device.
+		 * 
+		 * @throw tc::io::IOException An I/O error occurs.
+		 * @throw tc::ObjectDisposedException Methods were called after the stream was closed.
+		 **/
+	void flush();
+	
+		/**
+		 * @brief Releases internal resources including base stream and clears internal state.
+		 **/
+	void dispose();
+private:
+	static const std::string kClassName;
+
+	size_t mLength;
+	size_t mCurrentPos;
+
+	struct IndirectEntry {
+		std::shared_ptr<tc::io::IStream> mReader;
+		// offset in mReader (source offset)
+		int64_t physical_offset;
+		// destination offset
+		int64_t virtual_offset;
+		int64_t size;
+	};
+	// Map to relate a final Stream offset and IStream and offset where the data are
+	std::map<int64_t, IndirectEntry> mIndirectEntries;
+
+	// Reader to read data from NCA base
+	std::shared_ptr<tc::io::IStream> mBaseReader;
+	// Reader to read data from update NCA
+	std::shared_ptr<tc::io::IStream> mPatchReader;
+};
+
+}} // namespace tc::crypto

--- a/include/pietendo/hac/BKTREncryptedStream.h
+++ b/include/pietendo/hac/BKTREncryptedStream.h
@@ -165,8 +165,8 @@ private:
 	size_t mCurrentPos;
 
 	struct IndirectEntry {
-		std::shared_ptr<tc::io::IStream> mReader;
-		// offset in mReader (source offset)
+		std::shared_ptr<tc::io::IStream> reader;
+		// offset in reader (source offset)
 		int64_t physical_offset;
 		// destination offset
 		int64_t virtual_offset;
@@ -181,4 +181,4 @@ private:
 	std::shared_ptr<tc::io::IStream> mPatchReader;
 };
 
-}} // namespace tc::crypto
+}} // namespace pie::hac

--- a/include/pietendo/hac/BKTRSubsectionEncryptedStream.h
+++ b/include/pietendo/hac/BKTRSubsectionEncryptedStream.h
@@ -163,7 +163,7 @@ private:
 	size_t mCurrentPos;
 
 	struct Subsection {
-		std::shared_ptr<tc::io::IStream> mReader;
+		std::shared_ptr<tc::io::IStream> reader;
 		int64_t offset;
 		int64_t end_offset;
 	};
@@ -172,4 +172,4 @@ private:
 	std::vector<std::shared_ptr<tc::io::IStream>> mStreams;
 };
 
-}} // namespace tc::crypto
+}} // namespace pie::hac

--- a/include/pietendo/hac/BKTRSubsectionEncryptedStream.h
+++ b/include/pietendo/hac/BKTRSubsectionEncryptedStream.h
@@ -56,10 +56,10 @@ public:
 		/** 
 		 * @brief Create BKTRSubsectionEncryptedStream
 		 * 
-		 * @param[in] stream     The base IStream object which this stream will decrypt data from.
-		 * @param[in] key        AES128 Encryption Key. See @ref key_t.
-		 * @param[in] counter    AES128-CTR Counter relative to offset 0x0 of the base stream. See @ref counter_t.
-		 * @param[in] patch_info BKTR section
+		 * @param[in] stream      The base IStream object which this stream will decrypt data from.
+		 * @param[in] key         AES128 Encryption Key. See @ref key_t.
+		 * @param[in] counter     AES128-CTR Counter relative to offset 0x0 of the base stream. See @ref counter_t.
+		 * @param[in] bucket_info AesCtrEx bucket info
 		 * 
 		 * @pre The sub stream must be a subset of the base stream.
 		 * @pre A stream must support seeking for @ref seek to work. 
@@ -67,7 +67,7 @@ public:
 		 * @throw tc::ArgumentNullException @p stream is a @p nullptr.
 		 * @throw tc::NotSupportedException The base stream does not support seeking or reading.
 		 **/
-	BKTRSubsectionEncryptedStream(const std::shared_ptr<tc::io::IStream>& stream, const key_t& key, const counter_t& counter, const pie::hac::sContentArchiveFsHeaderPatchInfo& patch_info);
+	BKTRSubsectionEncryptedStream(const std::shared_ptr<tc::io::IStream>& stream, const key_t& key, const counter_t& counter, const pie::hac::sContentArchiveBucketInfo& bucket_info);
 
 		/**
 		 * @brief Indicates whether the current stream supports reading.

--- a/include/pietendo/hac/BKTRSubsectionEncryptedStream.h
+++ b/include/pietendo/hac/BKTRSubsectionEncryptedStream.h
@@ -1,0 +1,175 @@
+	/**
+	 * @file    BKTRSubsectionEncryptedStream.h
+	 * @brief   Declaration of pie::hac::BKTRSubsectionEncryptedStream
+	 * @author  Sam (sagumamugas)
+	 * @version 0.1
+	 * @date    2023/01/10
+	 **/
+#pragma once
+#include <list>
+#include <tc/ByteData.h>
+#include <tc/io/IStream.h>
+#include <tc/crypto/Aes128CtrEncryptor.h>
+
+#include <tc/ArgumentOutOfRangeException.h>
+#include <tc/ObjectDisposedException.h>
+#include <tc/NotSupportedException.h>
+#include <tc/NotImplementedException.h>
+#include <tc/io/IOException.h>
+
+#include <pietendo/hac/define/nca.h>
+
+namespace pie { namespace hac {
+
+	/**
+	 * @class BKTRSubsectionEncryptedStream
+	 * @brief Class for reading subsections from a stream that is encrypted with AES128-CTR-EX (BKTR section).
+	 * @details This class takes an encrypted IStream, encryption parameters and creates an IStream that will transparently decrypt data when reading.
+	 */
+class BKTRSubsectionEncryptedStream : public tc::io::IStream
+{
+public:
+		/**
+		 * @brief This is the data-type for AES128-CTR key used with Aes128CtrEncryptedStream.
+		 * 
+		 */
+	using key_t = std::array<byte_t, tc::crypto::Aes128CtrEncryptor::kKeySize>;
+
+		/**
+		 * @brief This is the data-type for AES128-CTR block counter used with Aes128CtrEncryptedStream.
+		 * 
+		 */
+	using counter_t = std::array<byte_t, tc::crypto::Aes128CtrEncryptor::kBlockSize>;
+
+		/**
+		 * @brief This is the data-type for AES128-CTR data block used with Aes128CtrEncryptedStream.
+		 * 
+		 */
+	using block_t = std::array<byte_t, tc::crypto::Aes128CtrEncryptor::kBlockSize>;
+
+		/**
+		 * @brief Default Constructor
+		 * @post This will create an uninitialized BKTRSubsectionEncryptedStream, it will have to be assigned from a valid BKTRSubsectionEncryptedStream object to be usable.
+		 **/
+	BKTRSubsectionEncryptedStream();
+
+		/** 
+		 * @brief Create BKTRSubsectionEncryptedStream
+		 * 
+		 * @param[in] stream     The base IStream object which this stream will decrypt data from.
+		 * @param[in] key        AES128 Encryption Key. See @ref key_t.
+		 * @param[in] counter    AES128-CTR Counter relative to offset 0x0 of the base stream. See @ref counter_t.
+		 * @param[in] patch_info BKTR section
+		 * 
+		 * @pre The sub stream must be a subset of the base stream.
+		 * @pre A stream must support seeking for @ref seek to work. 
+		 * 
+		 * @throw tc::ArgumentNullException @p stream is a @p nullptr.
+		 * @throw tc::NotSupportedException The base stream does not support seeking or reading.
+		 **/
+	BKTRSubsectionEncryptedStream(const std::shared_ptr<tc::io::IStream>& stream, const key_t& key, const counter_t& counter, const pie::hac::sContentArchiveFsHeaderPatchInfo& patch_info);
+
+		/**
+		 * @brief Indicates whether the current stream supports reading.
+		 **/ 
+	bool canRead() const;
+
+		/**
+		 * @brief Indicates whether the current stream supports writing.
+		 **/
+	bool canWrite() const;
+
+		/**
+		 * @brief Indicates whether the current stream supports seeking.
+		 **/
+	bool canSeek() const;
+
+		/**
+		 * @brief Gets the length in bytes of the stream.
+		 **/
+	int64_t length();
+
+		/** 
+		 * @brief Gets the position within the current stream. 
+		 * 
+		 * @return This is returns the current position within the stream.
+		 **/
+	int64_t position();
+
+		/**
+		 * @brief Reads a sequence of bytes from the current stream and advances the position within the stream by the number of bytes read.
+		 * 
+		 * @param[out] ptr Pointer to an array of bytes. When this method returns, @p ptr contains the specified byte array with the values between 0 and (@p count - 1) replaced by the bytes read from the current source.
+		 * @param[in] count The maximum number of bytes to be read from the current stream.
+		 * 
+		 * @return The total number of bytes read into @p ptr. This can be less than the number of bytes requested if that many bytes are not currently available, or zero (0) if the end of the stream has been reached.
+		 * 
+		 * @pre A stream must support reading for @ref read to work. 
+		 * @note Use @ref canRead to determine if this stream supports reading.
+		 * @note Exceptions thrown by the base stream are not altered/intercepted, refer to that module's documentation for those exceptions.
+		 * 
+		 * @throw tc::ArgumentOutOfRangeException @p count exceeds the length of readable data in the sub stream.
+		 * @throw tc::ObjectDisposedException Methods were called after the stream was closed.
+		 **/
+	size_t read(byte_t* ptr, size_t count);
+
+		/**
+		 * @brief Writes a sequence of bytes to the current stream and advances the current position within this stream by the number of bytes written. @ref write is not implemented for @ref BKTRSubsectionEncryptedStream.
+		 * @throw tc::NotImplementedException @ref write is not implemented for @ref BKTRSubsectionEncryptedStream.
+		 * @throw tc::ObjectDisposedException Methods were called after the stream was closed.
+		 **/
+	size_t write(const byte_t* ptr, size_t count);
+
+		/**
+		 * @brief Sets the position within the current stream.
+		 * 
+		 * @param[in] offset A byte offset relative to the origin parameter.
+		 * @param[in] origin A value of type @ref tc::io::SeekOrigin indicating the reference point used to obtain the new position.
+		 * 
+		 * @return The new position within the current stream.
+		 * 
+		 * @pre A stream must support seeking for @ref seek to work. 
+		 * @note Use @ref canSeek to determine if this stream supports seeking.
+		 * @note Exceptions thrown by the base stream are not altered/intercepted, refer to that module's documentation for those exceptions.
+		 * 
+		 * @throw tc::ArgumentOutOfRangeException @p origin contains an invalid value.
+		 * @throw tc::ObjectDisposedException Methods were called after the stream was closed.
+		 **/
+	int64_t seek(int64_t offset, tc::io::SeekOrigin origin);
+
+		/**
+		 * @brief Sets the length of the current stream. This is not implemented for @ref BKTRSubsectionEncryptedStream.
+		 * @throw tc::NotImplementedException @ref setLength is not implemented for @ref BKTRSubsectionEncryptedStream.
+		 * @throw tc::ObjectDisposedException Methods were called after the stream was closed.
+		 **/
+	void setLength(int64_t length);
+
+		/**
+		 * @brief Clears all buffers for this and the base stream and causes any buffered data to be written to the underlying device.
+		 * 
+		 * @throw tc::io::IOException An I/O error occurs.
+		 * @throw tc::ObjectDisposedException Methods were called after the stream was closed.
+		 **/
+	void flush();
+	
+		/**
+		 * @brief Releases internal resources including base stream and clears internal state.
+		 **/
+	void dispose();
+private:
+	static const std::string kClassName;
+
+	size_t mLength;
+	size_t mCurrentPos;
+
+	struct Subsection {
+		std::shared_ptr<tc::io::IStream> mReader;
+		int64_t offset;
+		int64_t end_offset;
+	};
+	std::map<int64_t, Subsection> mSubsections;
+
+	std::vector<std::shared_ptr<tc::io::IStream>> mStreams;
+};
+
+}} // namespace tc::crypto

--- a/include/pietendo/hac/define/indirectstorage.h
+++ b/include/pietendo/hac/define/indirectstorage.h
@@ -15,6 +15,11 @@ namespace indirectstorage
 {
 	static const int32_t kStorageCount = 2;
 	static const size_t kNodeSize = 0x4000; // 16KB
+
+	enum StorageSource {
+		StorageSource_BaseRomFs = 0,
+		StorageSource_PatchRomFs = 1,
+	};
 }
 
 #pragma pack(push,1)
@@ -25,6 +30,43 @@ struct sIndirectStorageEntry
 	tc::bn::le32<int32_t> storage_index;
 };
 static_assert(sizeof(sIndirectStorageEntry) == 0x14, "sIndirectStorageEntry size.");
+
+struct sIndirectStorageBucket
+{
+	union { // this union ensure size of kNodeSize
+		struct {
+			struct {
+				tc::bn::pad<4> reserved;
+				tc::bn::le32<uint32_t> entry_count;
+				tc::bn::le64<uint64_t> end_offset_bucket;
+			} header;
+			std::array<sIndirectStorageEntry, (0x4000 - sizeof(header)) / sizeof(sIndirectStorageEntry)> entries;
+		};
+		std::array<byte_t, indirectstorage::kNodeSize> raw;
+	};
+};
+static_assert(sizeof(sIndirectStorageBucket) == indirectstorage::kNodeSize, "sIndirectStorageBucket size.");
+
+#ifdef _WIN32
+#pragma warning(disable : 4200) // silence warnings for usage of empty arrays in stucts 
+#endif
+
+struct sIndirectStorageBlock
+{
+	struct {
+		std::array<byte_t, 0x4> reserved_0;
+		tc::bn::le32<uint32_t> bucket_count;
+		tc::bn::le64<uint64_t> total_size;
+	} header;
+	std::array<tc::bn::le64<uint64_t>, (0x4000 - sizeof(header)) / sizeof(tc::bn::le64<uint64_t>)> base_virtual_bucket_offset;
+	sIndirectStorageBucket buckets[];
+};
+static_assert(sizeof(sIndirectStorageBlock) == 0x4000, "sIndirectStorageBlock size.");
+
+#ifdef _WIN32
+#pragma warning(default : 4200)
+#endif
+
 #pragma pack(pop)
 
 }} // namespace pie::hac

--- a/src/hac/BKTREncryptedStream.cpp
+++ b/src/hac/BKTREncryptedStream.cpp
@@ -66,7 +66,7 @@ pie::hac::BKTREncryptedStream::BKTREncryptedStream(const std::shared_ptr<tc::io:
 
 	// Prepare base reader (from base NCA) and patch reader (from update NCA)
 	mBaseReader = base;
-	mPatchReader = std::make_shared<pie::hac::BKTRSubsectionEncryptedStream>(pie::hac::BKTRSubsectionEncryptedStream(stream, key, counter, patch_info));
+	mPatchReader = std::make_shared<pie::hac::BKTRSubsectionEncryptedStream>(pie::hac::BKTRSubsectionEncryptedStream(stream, key, counter, patch_info.aes_ctr_ex_bucket));
 	
 	mLength = indirect_block->header.total_size;
 	int64_t end_virtual_offset = indirect_block->header.total_size;

--- a/src/hac/BKTREncryptedStream.cpp
+++ b/src/hac/BKTREncryptedStream.cpp
@@ -91,15 +91,15 @@ pie::hac::BKTREncryptedStream::BKTREncryptedStream(const std::shared_ptr<tc::io:
 			// Select reader for each indirect storage entry
 			switch (entry.storage_index) 
 			{
-				case indirectstorage::StorageSource_BaseRomFs:
-					indirect_entry.reader = mBaseReader;
-					break;
-				case indirectstorage::StorageSource_PatchRomFs:
-					indirect_entry.reader = mPatchReader;
-					break;
-				default:
-					throw tc::NotSupportedException(kClassName, fmt::format("StorageSource({:d}) not supported", entry.storage_index));
-					break;
+			case indirectstorage::StorageSource_BaseRomFs:
+				indirect_entry.reader = mBaseReader;
+				break;
+			case indirectstorage::StorageSource_PatchRomFs:
+				indirect_entry.reader = mPatchReader;
+				break;
+			default:
+				throw tc::NotSupportedException(kClassName, fmt::format("StorageSource({:d}) not supported", entry.storage_index));
+				break;
 			}
 			indirect_entry.physical_offset = entry.phys_offset;
 			indirect_entry.virtual_offset = virtual_offset;

--- a/src/hac/BKTREncryptedStream.cpp
+++ b/src/hac/BKTREncryptedStream.cpp
@@ -1,0 +1,256 @@
+#include <pietendo/hac/BKTREncryptedStream.h>
+#include <tc/io/IOUtil.h>
+#include <tc/io/StreamUtil.h>
+
+#include <pietendo/hac/BKTRSubsectionEncryptedStream.h>
+
+#include <pietendo/hac/define/indirectstorage.h>
+
+#include <fmt/format.h>
+/*
+#include <fmt/core.h>
+#include <tc/cli/FormatUtil.h>
+*/
+#include <cassert>
+
+// inline utils
+inline int64_t virtualToPhysical(int64_t virtual_begin, int64_t physical_begin, int64_t virtual_offset) {
+	return physical_begin + (virtual_offset - virtual_begin);
+}
+
+const std::string pie::hac::BKTREncryptedStream::kClassName = "pie::hac::BKTREncryptedStream";
+
+pie::hac::BKTREncryptedStream::BKTREncryptedStream() :
+	mLength(0),
+	mCurrentPos(0),
+	mIndirectEntries(),
+	mBaseReader(nullptr),
+	mPatchReader(nullptr)
+{
+}
+
+pie::hac::BKTREncryptedStream::BKTREncryptedStream(const std::shared_ptr<tc::io::IStream>& stream, const key_t& key, const counter_t& counter, const pie::hac::sContentArchiveFsHeaderPatchInfo& patch_info, const std::shared_ptr<tc::io::IStream>& base) :
+	BKTREncryptedStream()
+{
+	// validate stream properties
+	if (stream == nullptr)
+	{
+		throw tc::ObjectDisposedException(kClassName, "stream is null.");
+	}
+	if (stream->canRead() == false)
+	{
+		throw tc::NotSupportedException(kClassName, "stream does not support reading.");
+	}
+	if (stream->canSeek() == false)
+	{
+		throw tc::NotSupportedException(kClassName, "stream does not support seeking.");
+	}
+	if (base == nullptr)
+	{
+		throw tc::ObjectDisposedException(kClassName, "baseStream is null.");
+	}
+	if (base->canRead() == false)
+	{
+		throw tc::NotSupportedException(kClassName, "baseStream does not support reading.");
+	}
+	if (base->canSeek() == false)
+	{
+		throw tc::NotSupportedException(kClassName, "baseStream does not support seeking.");
+	}
+
+	tc::crypto::Aes128CtrEncryptedStream sections_reader(stream, key, counter);
+
+	// validate and read indirect section
+	if (sections_reader.length() < patch_info.indirect_bucket.offset.unwrap() + patch_info.indirect_bucket.size.unwrap())
+	{
+		throw tc::ArgumentOutOfRangeException(kClassName, "Input stream is too small.");
+	}
+	tc::ByteData tmp_data = tc::ByteData(patch_info.indirect_bucket.size.unwrap());
+	sections_reader.seek(patch_info.indirect_bucket.offset.unwrap(), tc::io::SeekOrigin::Begin);
+	sections_reader.read(tmp_data.data(), tmp_data.size() );
+	const pie::hac::sIndirectStorageBlock* indirectBlock = (const pie::hac::sIndirectStorageBlock*)tmp_data.data();
+
+	// Prepare base reader (from base NCA) and patch reader (from update NCA)
+	mBaseReader = base;
+	mPatchReader = std::make_shared<BKTRSubsectionEncryptedStream>(pie::hac::BKTRSubsectionEncryptedStream(stream, key, counter, patch_info));
+	
+	mLength = indirectBlock->header.total_size;
+	int64_t end_virtual_offset = indirectBlock->header.total_size;
+
+	// Reverse lookup to save size from virtual offset
+	for (size_t i = indirectBlock->header.bucket_count; i > 0; --i) {
+		const sIndirectStorageBucket& bucket = indirectBlock->buckets[i - 1];
+		int64_t base_virtual_offset = indirectBlock->base_virtual_bucket_offset[i - 1];
+		for (size_t j = bucket.header.entry_count; j > 0; --j) {
+			const sIndirectStorageEntry& entry = bucket.entries[j - 1];
+			int64_t virtual_offset = base_virtual_offset + entry.virt_offset;
+
+			// Check ordered entries
+			if (virtual_offset > end_virtual_offset) {
+				throw tc::InvalidOperationException(kClassName, "Indirec storage not ascending ordered.");
+			}
+
+			IndirectEntry& indirect_entry = mIndirectEntries[virtual_offset];
+			// Select reader for each indirect storage entry
+			switch (entry.storage_index) {
+			case indirectstorage::StorageSource_BaseRomFs:
+				indirect_entry.mReader = mBaseReader;
+				break;
+			case indirectstorage::StorageSource_PatchRomFs:
+				indirect_entry.mReader = mPatchReader;
+				break;
+			default:
+				throw tc::NotSupportedException(kClassName, fmt::format("StorageSource({:d}) not supported", entry.storage_index));
+				break;
+			}
+			indirect_entry.physical_offset = entry.phys_offset;
+			indirect_entry.virtual_offset = virtual_offset;
+
+			indirect_entry.size = end_virtual_offset - indirect_entry.virtual_offset;
+			end_virtual_offset = virtual_offset;
+		}
+	}
+}
+
+bool pie::hac::BKTREncryptedStream::canRead() const
+{
+	if (mBaseReader == nullptr || !mBaseReader->canRead()) {
+		return false;
+	}
+	if (mPatchReader == nullptr || !mPatchReader->canRead()) {
+		return false;
+	}
+	return true;
+}
+
+bool pie::hac::BKTREncryptedStream::canWrite() const
+{
+	return false; // always false this is a read-only stream
+}
+bool pie::hac::BKTREncryptedStream::canSeek() const
+{
+	if (mBaseReader == nullptr || !mBaseReader->canSeek()) {
+		return false;
+	}
+	if (mPatchReader == nullptr || !mPatchReader->canSeek()) {
+		return false;
+	}
+	return true;
+}
+
+int64_t pie::hac::BKTREncryptedStream::length()
+{
+	return mLength;
+}
+
+int64_t pie::hac::BKTREncryptedStream::position()
+{
+	return mCurrentPos;
+}
+
+size_t pie::hac::BKTREncryptedStream::read(byte_t* ptr, size_t count)
+{
+	// track read_count
+	size_t data_read_count = 0;
+
+	// get predicted read count
+	count = tc::io::IOUtil::getReadableCount(this->length(), this->position(), count);
+	
+	// if count is 0 just return
+	if (count == 0) return data_read_count;
+
+	// get current position
+	int64_t current_pos = mCurrentPos;
+	if (current_pos < 0)
+	{
+		throw tc::InvalidOperationException(kClassName+"::read()", "Current stream position is negative.");
+	}
+
+	// get indirect storage info for current position
+	// upper_bound returns first key is greater than key, it means next entry (so need to get previous entry)
+	// map must to contain an entry for offset 0, but never retrieve by upper bound (because the key returned must be greater)
+	// and in case ask for a offset greater (or equal) to last entry its return "end", so its safe to get previous entry
+	const IndirectEntry& entry = (--mIndirectEntries.upper_bound(current_pos))->second;
+
+	std::shared_ptr<IStream> reader = entry.mReader;
+
+	// determine begin & end offsets
+	int64_t begin_read_offset	= current_pos;
+	int64_t end_read_offset	  = begin_read_offset + tc::io::IOUtil::castSizeToInt64(count);
+	int64_t count_first_relocation = count;
+	int64_t end_first_relocation = entry.virtual_offset + entry.size;
+
+	// check 
+	if (end_read_offset > end_first_relocation) {
+		// Read for first relocation
+		count_first_relocation = end_first_relocation - begin_read_offset;
+	}
+
+	int64_t physical_reader_offset = virtualToPhysical(entry.virtual_offset, entry.physical_offset, begin_read_offset);
+	reader->seek(physical_reader_offset, tc::io::SeekOrigin::Begin);
+	data_read_count += reader->read(ptr, count_first_relocation);
+
+	if (count_first_relocation != count) {
+		// update position to continue reading
+		seek(count_first_relocation, tc::io::SeekOrigin::Current);
+		// read data from other(s) storages (recursively)
+		data_read_count += read(ptr + count_first_relocation, count - count_first_relocation);
+	}
+
+	// update expected logical position
+	this->seek(begin_read_offset + tc::io::IOUtil::castSizeToInt64(data_read_count), tc::io::SeekOrigin::Begin);
+
+	// return data read count
+	return data_read_count;
+}
+
+size_t pie::hac::BKTREncryptedStream::write(const byte_t* ptr, size_t count)
+{
+	throw tc::NotImplementedException(kClassName+"::write()", "write is not implemented for BKTREncryptedStream");
+}
+
+int64_t pie::hac::BKTREncryptedStream::seek(int64_t offset, tc::io::SeekOrigin origin)
+{
+	return mCurrentPos = tc::io::StreamUtil::getSeekResult(offset, origin, mCurrentPos, mLength);
+}
+
+void pie::hac::BKTREncryptedStream::setLength(int64_t length)
+{
+	throw tc::NotImplementedException(kClassName+"::setLength()", "setLength is not implemented for BKTREncryptedStream");
+}
+
+void pie::hac::BKTREncryptedStream::flush()
+{
+	if (mBaseReader == nullptr)
+	{
+		throw tc::ObjectDisposedException(kClassName+"::seek()", "Failed to flush base stream (stream is disposed)");
+	}
+	mBaseReader->flush();
+
+	if (mPatchReader == nullptr)
+	{
+		throw tc::ObjectDisposedException(kClassName + "::seek()", "Failed to flush patch stream (stream is disposed)");
+	}
+	mPatchReader->flush();
+}
+
+void pie::hac::BKTREncryptedStream::dispose()
+{
+	if (mBaseReader != nullptr)
+	{
+		// dispose base stream
+		mBaseReader->dispose();
+
+		// release ptr
+		mBaseReader.reset();
+	}
+	if (mPatchReader != nullptr)
+	{
+		// dispose base stream
+		mPatchReader->dispose();
+
+		// release ptr
+		mPatchReader.reset();
+	}
+	mIndirectEntries.clear();
+}

--- a/src/hac/BKTRSubsectionEncryptedStream.cpp
+++ b/src/hac/BKTRSubsectionEncryptedStream.cpp
@@ -29,7 +29,7 @@ pie::hac::BKTRSubsectionEncryptedStream::BKTRSubsectionEncryptedStream() :
 {
 }
 
-pie::hac::BKTRSubsectionEncryptedStream::BKTRSubsectionEncryptedStream(const std::shared_ptr<tc::io::IStream>& stream, const key_t& key, const counter_t& counter, const pie::hac::sContentArchiveFsHeaderPatchInfo& patch_info) :
+pie::hac::BKTRSubsectionEncryptedStream::BKTRSubsectionEncryptedStream(const std::shared_ptr<tc::io::IStream>& stream, const key_t& key, const counter_t& counter, const pie::hac::sContentArchiveBucketInfo& bucket_info) :
 	BKTRSubsectionEncryptedStream()
 {
 	// validate stream properties
@@ -49,12 +49,12 @@ pie::hac::BKTRSubsectionEncryptedStream::BKTRSubsectionEncryptedStream(const std
 	tc::crypto::Aes128CtrEncryptedStream sections_reader(stream, key, counter);
 
 	// validate and read subsection header
-	if (sections_reader.length() < patch_info.aes_ctr_ex_bucket.offset.unwrap() + patch_info.aes_ctr_ex_bucket.size.unwrap())
+	if (sections_reader.length() < bucket_info.offset.unwrap() + bucket_info.size.unwrap())
 	{
 		throw tc::ArgumentOutOfRangeException(kClassName, "Input stream is too small.");
 	}
-	tc::ByteData subsection_block_raw = tc::ByteData(patch_info.aes_ctr_ex_bucket.size.unwrap());
-	sections_reader.seek(patch_info.aes_ctr_ex_bucket.offset.unwrap(), tc::io::SeekOrigin::Begin);
+	tc::ByteData subsection_block_raw = tc::ByteData(bucket_info.size.unwrap());
+	sections_reader.seek(bucket_info.offset.unwrap(), tc::io::SeekOrigin::Begin);
 	sections_reader.read(subsection_block_raw.data(), subsection_block_raw.size());
 	const pie::hac::sAesCtrExStorageBlock* subsection_block = (const pie::hac::sAesCtrExStorageBlock*)subsection_block_raw.data();
 

--- a/src/hac/BKTRSubsectionEncryptedStream.cpp
+++ b/src/hac/BKTRSubsectionEncryptedStream.cpp
@@ -1,0 +1,210 @@
+#include <pietendo/hac/BKTRSubsectionEncryptedStream.h>
+#include <tc/io/IOUtil.h>
+#include <tc/io/StreamUtil.h>
+
+#include <pietendo/hac/define/aesctrexstorage.h>
+/*
+#include <fmt/core.h>
+#include <tc/cli/FormatUtil.h>
+*/
+
+// inline utils
+inline uint64_t castInt64ToUint64(int64_t val) { return val < 0 ? 0 : uint64_t(val); }
+inline int64_t castUint64ToInt64(uint64_t val) { return (int64_t)std::min<uint64_t>(val, uint64_t(std::numeric_limits<int64_t>::max())); }
+
+inline uint64_t offsetToBlockIndex(int64_t offset) { return castInt64ToUint64(offset / tc::io::IOUtil::castSizeToInt64(tc::crypto::Aes128CtrEncryptor::kBlockSize)); };
+inline int64_t blockIndexToOffset(uint64_t block_index) { return castUint64ToInt64(block_index) * tc::io::IOUtil::castSizeToInt64(tc::crypto::Aes128CtrEncryptor::kBlockSize); };
+
+inline size_t lengthToBlockNum(int64_t length) { return tc::io::IOUtil::castInt64ToSize(length / tc::io::IOUtil::castSizeToInt64(tc::crypto::Aes128CtrEncryptor::kBlockSize)); };
+inline size_t offsetInBlock(int64_t offset) { return tc::io::IOUtil::castInt64ToSize(offset % tc::io::IOUtil::castSizeToInt64(tc::crypto::Aes128CtrEncryptor::kBlockSize)); };
+
+const std::string pie::hac::BKTRSubsectionEncryptedStream::kClassName = "pie::hac::BKTRSubsectionEncryptedStream";
+
+
+void setGenerationAesCtr(uint32_t generation, byte_t* aes_ctr)
+{
+	tc::bn::be32<uint32_t>* aes_ctr_words = (tc::bn::be32<uint32_t>*)aes_ctr;
+	aes_ctr_words[1].wrap(generation);
+}
+
+pie::hac::BKTRSubsectionEncryptedStream::BKTRSubsectionEncryptedStream() :
+	mLength(0),
+	mCurrentPos(0)
+{
+}
+
+pie::hac::BKTRSubsectionEncryptedStream::BKTRSubsectionEncryptedStream(const std::shared_ptr<tc::io::IStream>& stream, const key_t& key, const counter_t& counter, const pie::hac::sContentArchiveFsHeaderPatchInfo& patch_info) :
+	BKTRSubsectionEncryptedStream()
+{
+	// validate stream properties
+	if (stream == nullptr)
+	{
+		throw tc::ObjectDisposedException(kClassName, "stream is null.");
+	}
+	if (stream->canRead() == false)
+	{
+		throw tc::NotSupportedException(kClassName, "stream does not support reading.");
+	}
+	if (stream->canSeek() == false)
+	{
+		throw tc::NotSupportedException(kClassName, "stream does not support seeking.");
+	}
+
+	tc::crypto::Aes128CtrEncryptedStream sections_reader(stream, key, counter);
+
+	// validate and read subsection header
+	if (sections_reader.length() < patch_info.aes_ctr_ex_bucket.offset.unwrap() + patch_info.aes_ctr_ex_bucket.size.unwrap())
+	{
+		throw tc::ArgumentOutOfRangeException(kClassName, "Input stream is too small.");
+	}
+	tc::ByteData tmp_data = tc::ByteData(patch_info.aes_ctr_ex_bucket.size.unwrap());
+	sections_reader.seek(patch_info.aes_ctr_ex_bucket.offset.unwrap(), tc::io::SeekOrigin::Begin);
+	sections_reader.read(tmp_data.data(), tmp_data.size());
+	const pie::hac::sAesCtrExStorageBlock* subsectionBlock = (const pie::hac::sAesCtrExStorageBlock*)tmp_data.data();
+
+	mLength = stream->length();
+	auto new_counter = counter;
+
+	// Relation generation -> decrypted IStream
+	std::map<uint32_t, std::shared_ptr<tc::io::IStream>> generationMap;
+
+	for (size_t i = 0; i < subsectionBlock->header.bucket_count; ++i) {
+		const sAesCtrExStorageBucket& subsection = subsectionBlock->buckets[i];
+		for (size_t j = 0; j < subsection.header.entry_count; ++j) {
+			const sAesCtrExStorageEntry& entry = subsection.entries[j];
+			uint32_t newGeneration = entry.generation;
+			int64_t subsec_offset = entry.offset;
+			int64_t end_offset = (j + 1 == subsection.header.entry_count) ? subsection.header.end_offset_bucket : subsection.entries[j + 1].offset;
+			setGenerationAesCtr(newGeneration, new_counter.data());
+			std::shared_ptr<tc::io::IStream>& reader = generationMap[entry.generation];
+			if (reader == nullptr) {
+				reader = std::make_shared<tc::crypto::Aes128CtrEncryptedStream>(tc::crypto::Aes128CtrEncryptedStream(stream, key, new_counter));
+			}
+
+			Subsection& current_subsection = mSubsections[subsec_offset];
+			current_subsection.mReader = reader;
+			current_subsection.offset = subsec_offset;
+			current_subsection.end_offset = end_offset;
+		}
+	}
+}
+
+bool pie::hac::BKTRSubsectionEncryptedStream::canRead() const
+{
+	for (auto stream : mStreams) {
+		if (!stream->canRead())
+			return false;
+	}
+	return true;
+}
+
+bool pie::hac::BKTRSubsectionEncryptedStream::canWrite() const
+{
+	return false; // always false this is a read-only stream
+}
+bool pie::hac::BKTRSubsectionEncryptedStream::canSeek() const
+{
+	for (auto stream : mStreams) {
+		if (!stream->canSeek())
+			return false;
+	}
+	return true;
+}
+
+int64_t pie::hac::BKTRSubsectionEncryptedStream::length()
+{
+	return mLength;
+}
+
+int64_t pie::hac::BKTRSubsectionEncryptedStream::position()
+{
+	return mCurrentPos;
+}
+
+size_t pie::hac::BKTRSubsectionEncryptedStream::read(byte_t* ptr, size_t count)
+{
+	// track read_count
+	size_t data_read_count = 0;
+
+	// get predicted read count
+	count = tc::io::IOUtil::getReadableCount(this->length(), this->position(), count);
+	
+	// if count is 0 just return
+	if (count == 0) return data_read_count;
+
+	// get current position
+	int64_t current_pos = mCurrentPos;
+	if (current_pos < 0)
+	{
+		throw tc::InvalidOperationException(kClassName+"::read()", "Current stream position is negative.");
+	}
+
+	// get subsection info for current position
+	// upper_bound returns first key is greater than key, it means next entry (so need to get previous entry)
+	// map must to contain an entry for offset 0, but never retrieve by upper bound (because the key returned must be greater)
+	// and in case ask for a offset greater (or equal) to last entry its return "end", so its safe to get previous entry
+	const Subsection& section = (--mSubsections.upper_bound(current_pos))->second;
+
+	std::shared_ptr<IStream> reader = section.mReader;
+
+	// determine begin & end offsets
+	int64_t begin_read_offset    = current_pos;
+	int64_t end_read_offset      = begin_read_offset + tc::io::IOUtil::castSizeToInt64(count);
+	int64_t count_partial_read   = count;
+	int64_t end_offset_section = section.end_offset;
+
+	if (end_read_offset > end_offset_section) {
+		count_partial_read = end_offset_section - begin_read_offset;
+	}
+
+	reader->seek(begin_read_offset, tc::io::SeekOrigin::Begin);
+	data_read_count += reader->read(ptr, count_partial_read);
+
+	// reads from diferent subsections
+	if (count_partial_read != count) {
+		seek(count_partial_read, tc::io::SeekOrigin::Current);
+		// read remeaning data (recursively)
+		data_read_count += read(ptr + count_partial_read, count - count_partial_read);
+	}
+
+	// restore expected logical position
+	seek(begin_read_offset + tc::io::IOUtil::castSizeToInt64(data_read_count), tc::io::SeekOrigin::Begin);
+
+	// return data read count
+	return data_read_count;
+}
+
+size_t pie::hac::BKTRSubsectionEncryptedStream::write(const byte_t* ptr, size_t count)
+{
+	throw tc::NotImplementedException(kClassName+"::write()", "write is not implemented for BKTRSubsectionEncryptedStream");
+}
+
+int64_t pie::hac::BKTRSubsectionEncryptedStream::seek(int64_t offset, tc::io::SeekOrigin origin)
+{
+	return mCurrentPos = tc::io::StreamUtil::getSeekResult(offset, origin, mCurrentPos, mLength);
+}
+
+void pie::hac::BKTRSubsectionEncryptedStream::setLength(int64_t length)
+{
+	throw tc::NotImplementedException(kClassName+"::setLength()", "setLength is not implemented for BKTRSubsectionEncryptedStream");
+}
+
+void pie::hac::BKTRSubsectionEncryptedStream::flush()
+{
+	for (auto stream : mStreams) {
+		stream->flush();
+	}
+}
+
+void pie::hac::BKTRSubsectionEncryptedStream::dispose()
+{
+	for (auto stream : mStreams)
+	{
+		// dispose base stream
+		stream->dispose();
+
+		// release ptr
+		stream.reset();
+	}
+	mSubsections.clear();
+}

--- a/src/hac/HierarchicalIntegrityStream.cpp
+++ b/src/hac/HierarchicalIntegrityStream.cpp
@@ -270,7 +270,12 @@ size_t pie::hac::HierarchicalIntegrityStream::read(byte_t* ptr, size_t count)
 	{
 		// read block
 		this->seek(blockToOffset(partial_end_block), tc::io::SeekOrigin::Begin);
-		mDataStream->read(partial_block.data(), partial_block.size());
+		size_t data_read = mDataStream->read(partial_block.data(), partial_block.size());
+		// clean buffer (buffer may be full of rubbish from partial begin read
+		// and data stream can be not multiple of block size)
+		if (data_read < partial_block.size()) {
+			memset(partial_block.data() + data_read, 0, partial_block.size() - data_read);
+		}
 		
 		// verify block
 		if (validateLayerBlocksWithHashLayer(partial_block.data(), mDataStreamBlockSize, 1, getBlockHash(partial_end_block)) == false)


### PR DESCRIPTION
# About
This integrates changes done by @sagumamugas in #4

# Added
* Nintendo Switch Library (`pie::hac`)
  * Adds support for BKTR Encrypted Streams (NCA Patch format)
    * `class BKTREncryptedStream` - Class for reading from a stream that is encrypted with AES128-CTR-EX (BKTR section in NCA).
    * `class BKTRSubsectionEncryptedStream.` - Class for reading subsections from a stream that is encrypted with AES128-CTR-EX (BKTR section).

# Changes
* Nintendo Switch Library (`pie::hac`)
  * Fixed bug in `HierarchicalIntegrityStream` where partial final read could contain garbage data due to not handling physical data stream not being block aligned.