### PR TITLE
Fix bugs in RomFs processing.

### DIFF
--- a/include/pietendo/ctr/IvfcStream.h
+++ b/include/pietendo/ctr/IvfcStream.h
@@ -9,7 +9,7 @@
 #include <tc/ByteData.h>
 #include <tc/io/IStream.h>
 #include <tc/io/IOUtil.h>
-#include <tc/crypto/Sha256Generator.h>
+#include <tc/crypto/Sha2256Generator.h>
 #include <tc/crypto/CryptoException.h>
 
 #include <tc/ArgumentOutOfRangeException.h>
@@ -136,11 +136,11 @@ private:
 
 	// hash cache for data layer
 	tc::ByteData mHashCache;
-	inline byte_t* getBlockHash(size_t begin_block) { return mHashCache.data() + (begin_block * tc::crypto::Sha256Generator::kHashSize); }
+	inline byte_t* getBlockHash(size_t begin_block) { return mHashCache.data() + (begin_block * tc::crypto::Sha2256Generator::kHashSize); }
 
 	// hash calc temp
-	std::array<byte_t, tc::crypto::Sha256Generator::kHashSize> mHash;
-	tc::crypto::Sha256Generator mHashCalc;
+	std::array<byte_t, tc::crypto::Sha2256Generator::kHashSize> mHash;
+	tc::crypto::Sha2256Generator mHashCalc;
 
 	bool validateLayerBlocksWithHashLayer(const byte_t* layer, size_t block_size, size_t block_num, const byte_t* hash_layer);
 };

--- a/include/pietendo/hac/BKTREncryptedStream.h
+++ b/include/pietendo/hac/BKTREncryptedStream.h
@@ -2,8 +2,8 @@
 	 * @file    BKTREncryptedStream.h
 	 * @brief   Declaration of pie::hac::BKTREncryptedStream
 	 * @author  Sam (sagumamugas)
-	 * @version 0.1
-	 * @date    2023/01/10
+	 * @version 0.2
+	 * @date    2023/01/21
 	 **/
 #pragma once
 #include <list>
@@ -14,7 +14,6 @@
 #include <tc/ArgumentOutOfRangeException.h>
 #include <tc/ObjectDisposedException.h>
 #include <tc/NotSupportedException.h>
-#include <tc/NotImplementedException.h>
 #include <tc/io/IOException.h>
 
 #include <pietendo/hac/define/nca.h>
@@ -116,8 +115,8 @@ public:
 	size_t read(byte_t* ptr, size_t count);
 
 		/**
-		 * @brief Writes a sequence of bytes to the current stream and advances the current position within this stream by the number of bytes written. @ref write is not implemented for @ref BKTREncryptedStream.
-		 * @throw tc::NotImplementedException @ref write is not implemented for @ref BKTREncryptedStream.
+		 * @brief Writes a sequence of bytes to the current stream and advances the current position within this stream by the number of bytes written. @ref write is not supported for @ref BKTREncryptedStream.
+		 * @throw tc::NotSupportedException @ref write is not supported for @ref BKTREncryptedStream.
 		 * @throw tc::ObjectDisposedException Methods were called after the stream was closed.
 		 **/
 	size_t write(const byte_t* ptr, size_t count);
@@ -140,8 +139,8 @@ public:
 	int64_t seek(int64_t offset, tc::io::SeekOrigin origin);
 
 		/**
-		 * @brief Sets the length of the current stream. This is not implemented for @ref BKTREncryptedStream.
-		 * @throw tc::NotImplementedException @ref setLength is not implemented for @ref BKTREncryptedStream.
+		 * @brief Sets the length of the current stream. This is not supported for @ref BKTREncryptedStream.
+		 * @throw tc::NotSupportedException @ref setLength is not supported for @ref BKTREncryptedStream.
 		 * @throw tc::ObjectDisposedException Methods were called after the stream was closed.
 		 **/
 	void setLength(int64_t length);

--- a/include/pietendo/hac/BKTRSubsectionEncryptedStream.h
+++ b/include/pietendo/hac/BKTRSubsectionEncryptedStream.h
@@ -2,8 +2,8 @@
 	 * @file    BKTRSubsectionEncryptedStream.h
 	 * @brief   Declaration of pie::hac::BKTRSubsectionEncryptedStream
 	 * @author  Sam (sagumamugas)
-	 * @version 0.1
-	 * @date    2023/01/10
+	 * @version 0.2
+	 * @date    2023/01/21
 	 **/
 #pragma once
 #include <list>
@@ -14,7 +14,6 @@
 #include <tc/ArgumentOutOfRangeException.h>
 #include <tc/ObjectDisposedException.h>
 #include <tc/NotSupportedException.h>
-#include <tc/NotImplementedException.h>
 #include <tc/io/IOException.h>
 
 #include <pietendo/hac/define/nca.h>
@@ -114,8 +113,8 @@ public:
 	size_t read(byte_t* ptr, size_t count);
 
 		/**
-		 * @brief Writes a sequence of bytes to the current stream and advances the current position within this stream by the number of bytes written. @ref write is not implemented for @ref BKTRSubsectionEncryptedStream.
-		 * @throw tc::NotImplementedException @ref write is not implemented for @ref BKTRSubsectionEncryptedStream.
+		 * @brief Writes a sequence of bytes to the current stream and advances the current position within this stream by the number of bytes written. @ref write is not supported for @ref BKTRSubsectionEncryptedStream.
+		 * @throw tc::NotSupportedException @ref write is not supported for @ref BKTRSubsectionEncryptedStream.
 		 * @throw tc::ObjectDisposedException Methods were called after the stream was closed.
 		 **/
 	size_t write(const byte_t* ptr, size_t count);
@@ -138,8 +137,8 @@ public:
 	int64_t seek(int64_t offset, tc::io::SeekOrigin origin);
 
 		/**
-		 * @brief Sets the length of the current stream. This is not implemented for @ref BKTRSubsectionEncryptedStream.
-		 * @throw tc::NotImplementedException @ref setLength is not implemented for @ref BKTRSubsectionEncryptedStream.
+		 * @brief Sets the length of the current stream. This is not supported for @ref BKTRSubsectionEncryptedStream.
+		 * @throw tc::NotSupportedException @ref setLength is not supported for @ref BKTRSubsectionEncryptedStream.
 		 * @throw tc::ObjectDisposedException Methods were called after the stream was closed.
 		 **/
 	void setLength(int64_t length);

--- a/include/pietendo/hac/HierarchicalIntegrityStream.h
+++ b/include/pietendo/hac/HierarchicalIntegrityStream.h
@@ -9,7 +9,7 @@
 #include <tc/ByteData.h>
 #include <tc/io/IStream.h>
 #include <tc/io/IOUtil.h>
-#include <tc/crypto/Sha256Generator.h>
+#include <tc/crypto/Sha2256Generator.h>
 #include <tc/crypto/CryptoException.h>
 
 #include <tc/ArgumentOutOfRangeException.h>
@@ -138,11 +138,11 @@ private:
 
 	// hash cache for data layer
 	tc::ByteData mHashCache;
-	inline byte_t* getBlockHash(size_t begin_block) { return mHashCache.data() + (begin_block * tc::crypto::Sha256Generator::kHashSize); }
+	inline byte_t* getBlockHash(size_t begin_block) { return mHashCache.data() + (begin_block * tc::crypto::Sha2256Generator::kHashSize); }
 
 	// hash calc temp
-	std::array<byte_t, tc::crypto::Sha256Generator::kHashSize> mHash;
-	std::shared_ptr<tc::crypto::Sha256Generator> mHashCalc;
+	std::array<byte_t, tc::crypto::Sha2256Generator::kHashSize> mHash;
+	std::shared_ptr<tc::crypto::Sha2256Generator> mHashCalc;
 
 	bool validateLayerBlocksWithHashLayer(const byte_t* layer, size_t block_size, size_t block_num, const byte_t* hash_layer);
 };

--- a/include/pietendo/hac/HierarchicalIntegrityStream.h
+++ b/include/pietendo/hac/HierarchicalIntegrityStream.h
@@ -2,8 +2,8 @@
 	 * @file HierarchicalIntegrityStream.h
 	 * @brief Declaration of pie::hac::HierarchicalIntegrityStream
 	 * @author Jack (jakcron)
-	 * @version 0.1
-	 * @date 2022/06/28
+	 * @version 0.2
+	 * @date 2023/01/21
 	 **/
 #pragma once
 #include <tc/ByteData.h>
@@ -13,6 +13,7 @@
 #include <tc/crypto/CryptoException.h>
 
 #include <tc/ArgumentOutOfRangeException.h>
+#include <tc/NotSupportedException.h>
 #include <tc/ObjectDisposedException.h>
 
 #include <pietendo/hac/HierarchicalIntegrityHeader.h>
@@ -70,18 +71,8 @@ public:
 	size_t read(byte_t* ptr, size_t count);
 
 		/**
-		 * @brief Writes a sequence of bytes to the current stream and advances the current position within this stream by the number of bytes written.
-		 * 
-		 * @param[in] ptr Pointer to an array of bytes. This method copies @p count bytes from @p ptr to the current stream.
-		 * @param[in] count The number of bytes to be written to the current stream.
-		 * 
-		 * @return The total number of bytes written to the stream. This can be less than the number of bytes requested if that many bytes are not currently available, or zero (0) if the end of the stream has been reached.
-		 * 
-		 * @pre A stream must support writing for @ref write to work. 
-		 * @note Use @ref canWrite to determine if this stream supports writing.
-		 * @note Exceptions thrown by the base stream are not altered/intercepted, refer to that module's documentation for those exceptions.
-		 * 
-		 * @throw tc::ArgumentOutOfRangeException @p count exceeds the length of writeable data in the sub stream.
+		 * @brief Writes a sequence of bytes to the current stream and advances the current position within this stream by the number of bytes written. @ref write is not supported for @ref HierarchicalIntegrityStream.
+		 * @throw tc::NotSupportedException @ref write is not supported for @ref HierarchicalIntegrityStream.
 		 * @throw tc::ObjectDisposedException Methods were called after the stream was closed.
 		 **/
 	size_t write(const byte_t* ptr, size_t count);
@@ -104,8 +95,8 @@ public:
 	int64_t seek(int64_t offset, tc::io::SeekOrigin origin);
 
 		/**
-		 * @brief Sets the length of the current stream. This is not implemented for @ref SubStream.
-		 * @throw tc::NotImplementedException @ref setLength is not implemented for @ref SubStream
+		 * @brief Sets the length of the current stream. This is not supported for @ref SubStream.
+		 * @throw tc::NotSupportedException @ref setLength is not supported for @ref SubStream
 		 * @throw tc::ObjectDisposedException Methods were called after the stream was closed.
 		 **/
 	void setLength(int64_t length);

--- a/include/pietendo/hac/HierarchicalSha256Stream.h
+++ b/include/pietendo/hac/HierarchicalSha256Stream.h
@@ -9,7 +9,7 @@
 #include <tc/ByteData.h>
 #include <tc/io/IStream.h>
 #include <tc/io/IOUtil.h>
-#include <tc/crypto/Sha256Generator.h>
+#include <tc/crypto/Sha2256Generator.h>
 #include <tc/crypto/CryptoException.h>
 
 #include <tc/ArgumentOutOfRangeException.h>
@@ -141,11 +141,11 @@ private:
 
 	// hash cache for data layer
 	tc::ByteData mHashCache;
-	inline byte_t* getBlockHash(size_t begin_block) { return mHashCache.data() + (begin_block * tc::crypto::Sha256Generator::kHashSize); }
+	inline byte_t* getBlockHash(size_t begin_block) { return mHashCache.data() + (begin_block * tc::crypto::Sha2256Generator::kHashSize); }
 
 	// hash calc temp
-	std::array<byte_t, tc::crypto::Sha256Generator::kHashSize> mHash;
-	std::shared_ptr<tc::crypto::Sha256Generator> mHashCalc;
+	std::array<byte_t, tc::crypto::Sha2256Generator::kHashSize> mHash;
+	std::shared_ptr<tc::crypto::Sha2256Generator> mHashCalc;
 
 	bool validateLayerBlocksWithHashLayer(const byte_t* layer, size_t layer_size, size_t block_size, size_t block_num, const byte_t* hash_layer);
 };

--- a/include/pietendo/hac/HierarchicalSha256Stream.h
+++ b/include/pietendo/hac/HierarchicalSha256Stream.h
@@ -2,8 +2,8 @@
 	 * @file HierarchicalSha256Stream.h
 	 * @brief Declaration of pie::hac::HierarchicalSha256Stream
 	 * @author Jack (jakcron)
-	 * @version 0.1
-	 * @date 2022/06/28
+	 * @version 0.2
+	 * @date 2023/01/21
 	 **/
 #pragma once
 #include <tc/ByteData.h>
@@ -13,6 +13,7 @@
 #include <tc/crypto/CryptoException.h>
 
 #include <tc/ArgumentOutOfRangeException.h>
+#include <tc/NotSupportedException.h>
 #include <tc/ObjectDisposedException.h>
 
 #include <pietendo/hac/HierarchicalSha256Header.h>
@@ -70,18 +71,8 @@ public:
 	size_t read(byte_t* ptr, size_t count);
 
 		/**
-		 * @brief Writes a sequence of bytes to the current stream and advances the current position within this stream by the number of bytes written.
-		 * 
-		 * @param[in] ptr Pointer to an array of bytes. This method copies @p count bytes from @p ptr to the current stream.
-		 * @param[in] count The number of bytes to be written to the current stream.
-		 * 
-		 * @return The total number of bytes written to the stream. This can be less than the number of bytes requested if that many bytes are not currently available, or zero (0) if the end of the stream has been reached.
-		 * 
-		 * @pre A stream must support writing for @ref write to work. 
-		 * @note Use @ref canWrite to determine if this stream supports writing.
-		 * @note Exceptions thrown by the base stream are not altered/intercepted, refer to that module's documentation for those exceptions.
-		 * 
-		 * @throw tc::ArgumentOutOfRangeException @p count exceeds the length of writeable data in the sub stream.
+		 * @brief Writes a sequence of bytes to the current stream and advances the current position within this stream by the number of bytes written. @ref write is not supported for @ref HierarchicalSha256Stream.
+		 * @throw tc::NotSupportedException @ref write is not supported for @ref HierarchicalSha256Stream.
 		 * @throw tc::ObjectDisposedException Methods were called after the stream was closed.
 		 **/
 	size_t write(const byte_t* ptr, size_t count);
@@ -104,8 +95,8 @@ public:
 	int64_t seek(int64_t offset, tc::io::SeekOrigin origin);
 
 		/**
-		 * @brief Sets the length of the current stream. This is not implemented for @ref SubStream.
-		 * @throw tc::NotImplementedException @ref setLength is not implemented for @ref SubStream
+		 * @brief Sets the length of the current stream. This is not supported for @ref SubStream.
+		 * @throw tc::NotSupportedException @ref setLength is not supported for @ref SubStream
 		 * @throw tc::ObjectDisposedException Methods were called after the stream was closed.
 		 **/
 	void setLength(int64_t length);

--- a/include/pietendo/hac/define/types.h
+++ b/include/pietendo/hac/define/types.h
@@ -16,17 +16,17 @@ namespace pie { namespace hac { namespace detail {
 
 #pragma pack(push,1)
 
-using sha256_hash_t = std::array<byte_t, tc::crypto::Sha256Generator::kHashSize>;
+using sha256_hash_t = std::array<byte_t, tc::crypto::Sha2256Generator::kHashSize>;
 
 using aes128_key_t = std::array<byte_t, tc::crypto::Aes128CbcEncryptor::kKeySize>;
 using aes128_xtskey_t = std::array<aes128_key_t, 2>;
 using aes_iv_t = std::array<byte_t, tc::crypto::Aes128CbcEncryptor::kBlockSize>;
 
-using rsa2048_signature_t = std::array<byte_t, tc::crypto::Rsa2048Pkcs1Sha256Signer::kSignatureSize>;
-using rsa2048_block_t = std::array<byte_t, tc::crypto::Rsa2048OaepSha256Encryptor::kBlockSize>;
+using rsa2048_signature_t = std::array<byte_t, tc::crypto::Rsa2048Pkcs1Sha2256Signer::kSignatureSize>;
+using rsa2048_block_t = std::array<byte_t, tc::crypto::Rsa2048OaepSha2256Encryptor::kBlockSize>;
 
-using rsa4096_signature_t = std::array<byte_t, tc::crypto::Rsa4096Pkcs1Sha256Signer::kSignatureSize>;
-using rsa4096_block_t = std::array<byte_t, tc::crypto::Rsa4096OaepSha256Encryptor::kBlockSize>;
+using rsa4096_signature_t = std::array<byte_t, tc::crypto::Rsa4096Pkcs1Sha2256Signer::kSignatureSize>;
+using rsa4096_block_t = std::array<byte_t, tc::crypto::Rsa4096OaepSha2256Encryptor::kBlockSize>;
 
 using rights_id_t = std::array<byte_t, 16>;
 

--- a/include/pietendo/hac/es/ticket.h
+++ b/include/pietendo/hac/es/ticket.h
@@ -52,7 +52,7 @@ namespace ticket
 
 	static const size_t kIssuerSize = 0x40;
 	static const byte_t kFormatVersion = 2;
-	static const size_t kEncTitleKeySize = tc::crypto::Rsa2048OaepSha256Encryptor::kBlockSize;
+	static const size_t kEncTitleKeySize = tc::crypto::Rsa2048OaepSha2256Encryptor::kBlockSize;
 	static const size_t kReservedRegionSize = 8;
 	static const size_t kRightsIdSize = 16;
 }

--- a/src/ctr/CciFsSnapshotGenerator.cpp
+++ b/src/ctr/CciFsSnapshotGenerator.cpp
@@ -1,6 +1,6 @@
 #include <pietendo/ctr/CciFsSnapshotGenerator.h>
 #include <tc/io/SubStream.h>
-#include <tc/crypto/Sha256Generator.h>
+#include <tc/crypto/Sha2256Generator.h>
 
 #include <pietendo/ctr/cci.h>
 

--- a/src/ctr/CiaFsSnapshotGenerator.cpp
+++ b/src/ctr/CiaFsSnapshotGenerator.cpp
@@ -1,6 +1,6 @@
 #include <pietendo/ctr/CiaFsSnapshotGenerator.h>
 #include <tc/io/SubStream.h>
-#include <tc/crypto/Sha256Generator.h>
+#include <tc/crypto/Sha2256Generator.h>
 
 #include <pietendo/ctr/cia.h>
 #include <pietendo/es/tmd.h>
@@ -150,18 +150,18 @@ pie::ctr::CiaFsSnapshotGenerator::CiaFsSnapshotGenerator(const std::shared_ptr<t
 			}
 
 			// hash for staged validiation
-			std::array<byte_t, tc::crypto::Sha256Generator::kHashSize> hash;
+			std::array<byte_t, tc::crypto::Sha2256Generator::kHashSize> hash;
 
 			// TODO validate signature
 			/*
-			tc::crypto::GenerateSha256Hash(hash.data(), (byte_t*)&tmd->sig.issuer, (size_t)((byte_t*)&tmd->v1Head.cmdGroups - (byte_t*)&tmd->sig.issuer));
-			if (tc::crypto::VerifyRsa2048Pkcs1Sha256(tmd->sig.sig.data(), hash.data(), <rsa key here>))
+			tc::crypto::GenerateSha2256Hash(hash.data(), (byte_t*)&tmd->sig.issuer, (size_t)((byte_t*)&tmd->v1Head.cmdGroups - (byte_t*)&tmd->sig.issuer));
+			if (tc::crypto::VerifyRsa2048Pkcs1Sha2256(tmd->sig.sig.data(), hash.data(), <rsa key here>))
 			{
 				throw tc::ArgumentOutOfRangeException("pie::ctr::CiaFsMetaGenerator", "TMD had invalid signature.");
 			}
 			*/
 
-			tc::crypto::GenerateSha256Hash(hash.data(), (byte_t*)&tmd->v1Head.cmdGroups, sizeof(tmd->v1Head.cmdGroups));
+			tc::crypto::GenerateSha2256Hash(hash.data(), (byte_t*)&tmd->v1Head.cmdGroups, sizeof(tmd->v1Head.cmdGroups));
 			if (memcmp(hash.data(), tmd->v1Head.hash.data(), hash.size()) != 0)
 			{
 				throw tc::ArgumentOutOfRangeException("pie::ctr::CiaFsSnapshotGenerator", "TMD had invalid CMD group hash.");
@@ -182,7 +182,7 @@ pie::ctr::CiaFsSnapshotGenerator::CiaFsSnapshotGenerator(const std::shared_ptr<t
 				throw tc::ArgumentOutOfRangeException("pie::ctr::CiaFsSnapshotGenerator", "TMD had unexpected size");
 			}
 
-			tc::crypto::GenerateSha256Hash(hash.data(), (byte_t*)&tmd->contents, cmd_table_num * sizeof(pie::es::ESV1ContentMeta));
+			tc::crypto::GenerateSha2256Hash(hash.data(), (byte_t*)&tmd->contents, cmd_table_num * sizeof(pie::es::ESV1ContentMeta));
 			if (memcmp(hash.data(), tmd->v1Head.cmdGroups[0].groupHash.data(), hash.size()) != 0)
 			{
 				throw tc::ArgumentOutOfRangeException("pie::ctr::CiaFsSnapshotGenerator", "TMD had invalid CMD group[0] hash.");

--- a/src/ctr/ExeFsSnapshotGenerator.cpp
+++ b/src/ctr/ExeFsSnapshotGenerator.cpp
@@ -1,6 +1,6 @@
 #include <pietendo/ctr/ExeFsSnapshotGenerator.h>
 #include <tc/io/SubStream.h>
-#include <tc/crypto/Sha256Generator.h>
+#include <tc/crypto/Sha2256Generator.h>
 #include <tc/crypto/CryptoException.h>
 #include <tc/io/MemoryStream.h>
 
@@ -78,7 +78,7 @@ pie::ctr::ExeFsSnapshotGenerator::ExeFsSnapshotGenerator(const std::shared_ptr<t
 	dir_entry_path_map[tc::io::Path("/")] = dir_entries.size()-1;
 
 	// populate virtual filesystem
-	std::array<byte_t, tc::crypto::Sha256Generator::kHashSize> hash_tmp;
+	std::array<byte_t, tc::crypto::Sha2256Generator::kHashSize> hash_tmp;
 	for (size_t i = 0; i < section.size(); i++)
 	{
 		if (section[i].size != 0)
@@ -92,7 +92,7 @@ pie::ctr::ExeFsSnapshotGenerator::ExeFsSnapshotGenerator(const std::shared_ptr<t
 				stream->seek(section[i].offset + sizeof(pie::ctr::ExeFsHeader), tc::io::SeekOrigin::Begin);
 				stream->read(tmp_data.data(), tmp_data.size());
 
-				tc::crypto::GenerateSha256Hash(hash_tmp.data(), tmp_data.data(), tmp_data.size());
+				tc::crypto::GenerateSha2256Hash(hash_tmp.data(), tmp_data.data(), tmp_data.size());
 				if (memcmp(hash_tmp.data(), section[i].hash.data(), hash_tmp.size()) != 0)
 				{
 					throw tc::crypto::CryptoException("pie::ctr::ExeFsSnapshotGenerator", "File failed hash check.");

--- a/src/ctr/IvfcStream.cpp
+++ b/src/ctr/IvfcStream.cpp
@@ -131,15 +131,15 @@ pie::ctr::IvfcStream::IvfcStream(const std::shared_ptr<tc::io::IStream>& stream)
 	}
 
 	// validate hash tree
-	if ((section[DataLevel2].block_num * tc::crypto::Sha256Generator::kHashSize) != section[HashLevel1].size)
+	if ((section[DataLevel2].block_num * tc::crypto::Sha2256Generator::kHashSize) != section[HashLevel1].size)
 	{
 		throw tc::ArgumentOutOfRangeException("pie::ctr::IvfcStream", "IVFC level1 hash table had unexpected size.");
 	}
-	if ((section[HashLevel1].block_num * tc::crypto::Sha256Generator::kHashSize) != section[HashLevel0].size)
+	if ((section[HashLevel1].block_num * tc::crypto::Sha2256Generator::kHashSize) != section[HashLevel0].size)
 	{
 		throw tc::ArgumentOutOfRangeException("pie::ctr::IvfcStream", "IVFC level0 hash table had unexpected size.");
 	}
-	if ((section[HashLevel0].block_num * tc::crypto::Sha256Generator::kHashSize) != section[MasterHash].size)
+	if ((section[HashLevel0].block_num * tc::crypto::Sha2256Generator::kHashSize) != section[MasterHash].size)
 	{
 		throw tc::ArgumentOutOfRangeException("pie::ctr::IvfcStream", "IVFC master hash table had unexpected size.");
 	}
@@ -375,7 +375,7 @@ size_t pie::ctr::IvfcStream::read(byte_t* ptr, size_t count)
 
 size_t pie::ctr::IvfcStream::write(const byte_t* ptr, size_t count)
 {
-	throw tc::NotImplementedException(mModuleLabel+"::write()", "write is not supported for IvfcStream");
+	throw tc::NotSupportedException(mModuleLabel+"::write()", "write is not supported for IvfcStream");
 }
 
 int64_t pie::ctr::IvfcStream::seek(int64_t offset, tc::io::SeekOrigin origin)

--- a/src/ctr/RomFsSnapshotGenerator.cpp
+++ b/src/ctr/RomFsSnapshotGenerator.cpp
@@ -58,15 +58,28 @@ pie::ctr::RomFsSnapshotGenerator::RomFsSnapshotGenerator(const std::shared_ptr<t
 	mDataOffset = hdr.data_offset.unwrap();
 
 	// get dir entry ptr
-	mDirEntryTable = tc::ByteData(hdr.dir_entry.size.unwrap());
-	mBaseStream->seek(hdr.dir_entry.offset.unwrap(), tc::io::SeekOrigin::Begin);
-	mBaseStream->read(mDirEntryTable.data(), mDirEntryTable.size());
-	
+	if (hdr.dir_entry.size.unwrap() > 0)
+	{
+		mDirEntryTable = tc::ByteData(hdr.dir_entry.size.unwrap());
+		mBaseStream->seek(hdr.dir_entry.offset.unwrap(), tc::io::SeekOrigin::Begin);
+		mBaseStream->read(mDirEntryTable.data(), mDirEntryTable.size());
+	}
+	else
+	{
+		mDirEntryTable = tc::ByteData();
+	}
 
 	// get file entry ptr
-	mFileEntryTable = tc::ByteData(hdr.file_entry.size.unwrap());
-	mBaseStream->seek(hdr.file_entry.offset.unwrap(), tc::io::SeekOrigin::Begin);
-	mBaseStream->read(mFileEntryTable.data(), mFileEntryTable.size());
+	if (hdr.file_entry.size.unwrap() > 0)
+	{
+		mFileEntryTable = tc::ByteData(hdr.file_entry.size.unwrap());
+		mBaseStream->seek(hdr.file_entry.offset.unwrap(), tc::io::SeekOrigin::Begin);
+		mBaseStream->read(mFileEntryTable.data(), mFileEntryTable.size());
+	}
+	else
+	{
+		mFileEntryTable = tc::ByteData();
+	}
 
 	//std::cout << "DirTable:" << std::endl;
 	//std::cout << tc::cli::FormatUtil::formatBytesAsHxdHexString(mDirEntryTable.data(), mDirEntryTable.size());
@@ -121,7 +134,9 @@ pie::ctr::RomFsSnapshotGenerator::RomFsSnapshotGenerator(const std::shared_ptr<t
 	}
 	*/
 
-	if (getDirEntry(0)->parent_offset.unwrap() != 0 ||
+	// validate root directory entry
+ 	if (mDirEntryTable.size() == 0 ||
+		getDirEntry(0)->parent_offset.unwrap() != 0 ||
 	    getDirEntry(0)->sibling_offset.unwrap() != 0xffffffff ||
 	    getDirEntry(0)->name_size.unwrap() != 0)
 	{
@@ -180,14 +195,14 @@ pie::ctr::RomFsSnapshotGenerator::RomFsSnapshotGenerator(const std::shared_ptr<t
 		}
 		
 
-		uint32_t total_size = sizeof(pie::ctr::RomFsDirectoryEntry) + align<uint32_t>(getDirEntry(v_addr)->name_size.unwrap(), 4);
+		uint32_t entry_total_size = sizeof(pie::ctr::RomFsDirectoryEntry) + align<uint32_t>(getDirEntry(v_addr)->name_size.unwrap(), 4);
 
 		if (getDirEntry(v_addr)->sibling_offset.unwrap() < v_addr)
 		{
 			throw tc::InvalidOperationException("pie::ctr::RomFsSnapshotGenerator", "Possibly corrupted directory entry");
 		}
 
-		v_addr += total_size;
+		v_addr += entry_total_size;
 	}
 
 	// add files

--- a/src/ctr/RomFsSnapshotGenerator.cpp
+++ b/src/ctr/RomFsSnapshotGenerator.cpp
@@ -266,7 +266,7 @@ void pie::ctr::RomFsSnapshotGenerator::addFile(const pie::ctr::RomFsFileEntry* f
 	else
 	{
 		// empty stream
-		tmp.stream = std::shared_ptr<tc::io::SubStream>(new tc::io::SubStream());
+		tmp.stream = std::shared_ptr<tc::io::EmptyStream>(new tc::io::EmptyStream());
 	}
 
 	// save/transcode file name

--- a/src/ctr/es/Certificate.cpp
+++ b/src/ctr/es/Certificate.cpp
@@ -3,7 +3,7 @@
 
 #include <pietendo/es/cert.h>
 #include <tc/ByteData.h>
-#include <tc/crypto/Sha256Generator.h>
+#include <tc/crypto/Sha2256Generator.h>
 
 #include <tc/cli.h>
 
@@ -176,7 +176,7 @@ pie::ctr::es::CertificateDeserialiser::CertificateDeserialiser(const std::shared
 	{
 		throw tc::ArgumentOutOfRangeException(mModuleLabel, "CERT had unexpected size after reading.");
 	}
-	tc::crypto::GenerateSha256Hash(calculated_hash.data(), total_cert_data.data() + getCertificateSignableOffset(total_cert_data.data()), pie::ctr::es::getCertificateSignableSize(total_cert_data.data()));
+	tc::crypto::GenerateSha2256Hash(calculated_hash.data(), total_cert_data.data() + getCertificateSignableOffset(total_cert_data.data()), pie::ctr::es::getCertificateSignableSize(total_cert_data.data()));
 
 
 	// store properties

--- a/src/ctr/es/RsaSigner.cpp
+++ b/src/ctr/es/RsaSigner.cpp
@@ -1,7 +1,7 @@
 #include <pietendo/ctr/es/RsaSigner.h>
 
 #include <tc/crypto/RsaPkcs1Sha1Signer.h>
-#include <tc/crypto/RsaPkcs1Sha256Signer.h>
+#include <tc/crypto/RsaPkcs1Sha2256Signer.h>
 
 pie::ctr::es::RsaSigner::RsaSigner(pie::es::ESSigType sig_type, const std::string& issuer, const tc::crypto::RsaKey& rsa_key) :
 	mSigType(sig_type),
@@ -45,10 +45,10 @@ bool pie::ctr::es::RsaSigner::signHash(const byte_t* hash, byte_t* signature)
 			signSucceed = tc::crypto::SignRsa2048Pkcs1Sha1(signature, hash, mRsaKey);
 			break;
 		case pie::es::ESSigType_RSA4096_SHA2256:
-			signSucceed = tc::crypto::SignRsa4096Pkcs1Sha256(signature, hash, mRsaKey);
+			signSucceed = tc::crypto::SignRsa4096Pkcs1Sha2256(signature, hash, mRsaKey);
 			break;
 		case pie::es::ESSigType_RSA2048_SHA2256:
-			signSucceed = tc::crypto::SignRsa2048Pkcs1Sha256(signature, hash, mRsaKey);
+			signSucceed = tc::crypto::SignRsa2048Pkcs1Sha2256(signature, hash, mRsaKey);
 			break;
 		default:
 			signSucceed = false;
@@ -70,10 +70,10 @@ bool pie::ctr::es::RsaSigner::verifyHash(const byte_t* hash, const byte_t* signa
 			verifySucceed = tc::crypto::VerifyRsa2048Pkcs1Sha1(signature, hash, mRsaKey);
 			break;
 		case pie::es::ESSigType_RSA4096_SHA2256:
-			verifySucceed = tc::crypto::VerifyRsa4096Pkcs1Sha256(signature, hash, mRsaKey);
+			verifySucceed = tc::crypto::VerifyRsa4096Pkcs1Sha2256(signature, hash, mRsaKey);
 			break;
 		case pie::es::ESSigType_RSA2048_SHA2256:
-			verifySucceed = tc::crypto::VerifyRsa2048Pkcs1Sha256(signature, hash, mRsaKey);
+			verifySucceed = tc::crypto::VerifyRsa2048Pkcs1Sha2256(signature, hash, mRsaKey);
 			break;
 		default:
 			verifySucceed = false;

--- a/src/ctr/es/Signature.cpp
+++ b/src/ctr/es/Signature.cpp
@@ -3,7 +3,7 @@
 
 #include <pietendo/es/cert.h>
 #include <tc/ByteData.h>
-#include <tc/crypto/Sha256Generator.h>
+#include <tc/crypto/Sha2256Generator.h>
 
 #include <tc/cli.h>
 

--- a/src/ctr/es/Ticket.cpp
+++ b/src/ctr/es/Ticket.cpp
@@ -3,7 +3,7 @@
 
 #include <pietendo/es/ticket.h>
 #include <tc/ByteData.h>
-#include <tc/crypto/Sha256Generator.h>
+#include <tc/crypto/Sha2256Generator.h>
 
 #include <tc/cli.h>
 
@@ -129,7 +129,7 @@ pie::ctr::es::TicketDeserialiser::TicketDeserialiser(const std::shared_ptr<tc::i
 	// generate hash
 	byte_t* tik_hash_begin = (byte_t*)&tik->head.sig.issuer;
 	size_t tik_hash_size = tik_data.size() - size_t(tik_hash_begin - tik_data.data());
-	tc::crypto::GenerateSha256Hash(this->calculated_hash.data(), tik_hash_begin, tik_hash_size);
+	tc::crypto::GenerateSha2256Hash(this->calculated_hash.data(), tik_hash_begin, tik_hash_size);
 
 	// basic fields
 	this->signature.sig_type = tik->head.sig.sigType.unwrap();

--- a/src/ctr/es/TitleMetaData.cpp
+++ b/src/ctr/es/TitleMetaData.cpp
@@ -3,7 +3,7 @@
 
 #include <pietendo/es/tmd.h>
 #include <tc/ByteData.h>
-#include <tc/crypto/Sha256Generator.h>
+#include <tc/crypto/Sha2256Generator.h>
 
 pie::ctr::es::TitleMetaDataDeserialiser::TitleMetaDataDeserialiser(const std::shared_ptr<tc::io::IStream>& tmd_stream) :
 	TitleMetaData(),
@@ -68,20 +68,20 @@ pie::ctr::es::TitleMetaDataDeserialiser::TitleMetaDataDeserialiser(const std::sh
 	tmd = (pie::es::ESV1TitleMeta*)tmd_data.data();
 
 	// hash for staged validiation
-	std::array<byte_t, tc::crypto::Sha256Generator::kHashSize> hash;
+	std::array<byte_t, tc::crypto::Sha2256Generator::kHashSize> hash;
 
 	// calculate hash for optional signature validation later
-	tc::crypto::GenerateSha256Hash(calculated_hash.data(), (byte_t*)&tmd->sig.issuer, (size_t)((byte_t*)&tmd->v1Head.cmdGroups - (byte_t*)&tmd->sig.issuer));
+	tc::crypto::GenerateSha2256Hash(calculated_hash.data(), (byte_t*)&tmd->sig.issuer, (size_t)((byte_t*)&tmd->v1Head.cmdGroups - (byte_t*)&tmd->sig.issuer));
 
 	// verify v1 ESV1ContentMetaGroup array using hash in v1 header
-	tc::crypto::GenerateSha256Hash(hash.data(), (byte_t*)&tmd->v1Head.cmdGroups, sizeof(tmd->v1Head.cmdGroups));
+	tc::crypto::GenerateSha2256Hash(hash.data(), (byte_t*)&tmd->v1Head.cmdGroups, sizeof(tmd->v1Head.cmdGroups));
 	if (memcmp(hash.data(), tmd->v1Head.hash.data(), hash.size()) != 0)
 	{
 		throw tc::ArgumentOutOfRangeException(mModuleLabel, "TMD had invalid CMD group hash.");
 	}
 
 	// verify ESV1ContentMeta array
-	tc::crypto::GenerateSha256Hash(hash.data(), (byte_t*)&tmd->contents, cmd_table_num * sizeof(pie::es::ESV1ContentMeta));
+	tc::crypto::GenerateSha2256Hash(hash.data(), (byte_t*)&tmd->contents, cmd_table_num * sizeof(pie::es::ESV1ContentMeta));
 	if (memcmp(hash.data(), tmd->v1Head.cmdGroups[0].groupHash.data(), hash.size()) != 0)
 	{
 		throw tc::ArgumentOutOfRangeException(mModuleLabel, "TMD had invalid CMD group[0] hash.");

--- a/src/hac/AccessControlInfoDesc.cpp
+++ b/src/hac/AccessControlInfoDesc.cpp
@@ -174,9 +174,9 @@ void pie::hac::AccessControlInfoDesc::generateSignature(const tc::crypto::RsaKey
 		toBytes();
 
 	detail::sha256_hash_t hash;
-	tc::crypto::GenerateSha256Hash(hash.data(), mRawBinary.data() + sizeof(detail::rsa2048_signature_t), mRawBinary.size() - sizeof(detail::rsa2048_signature_t));
+	tc::crypto::GenerateSha2256Hash(hash.data(), mRawBinary.data() + sizeof(detail::rsa2048_signature_t), mRawBinary.size() - sizeof(detail::rsa2048_signature_t));
 
-	if (tc::crypto::SignRsa2048PssSha256(mRawBinary.data(), hash.data(), key) == false)
+	if (tc::crypto::SignRsa2048PssSha2256(mRawBinary.data(), hash.data(), key) == false)
 	{
 		throw tc::crypto::CryptoException(kModuleName, "Failed to sign Access Control Info Desc");
 	}
@@ -188,9 +188,9 @@ void pie::hac::AccessControlInfoDesc::validateSignature(const tc::crypto::RsaKey
 		throw tc::ArgumentOutOfRangeException(kModuleName, "No Access Control Info Desc binary exists to verify");
 
 	detail::sha256_hash_t hash;
-	tc::crypto::GenerateSha256Hash(hash.data(), mRawBinary.data() + sizeof(detail::rsa2048_signature_t), mRawBinary.size() - sizeof(detail::rsa2048_signature_t));
+	tc::crypto::GenerateSha2256Hash(hash.data(), mRawBinary.data() + sizeof(detail::rsa2048_signature_t), mRawBinary.size() - sizeof(detail::rsa2048_signature_t));
 
-	if (tc::crypto::VerifyRsa2048PssSha256(mRawBinary.data(), hash.data(), key) == false)
+	if (tc::crypto::VerifyRsa2048PssSha2256(mRawBinary.data(), hash.data(), key) == false)
 	{
 		throw tc::crypto::CryptoException(kModuleName, "Failed to verify Access Control Info Desc");
 	}

--- a/src/hac/BKTREncryptedStream.cpp
+++ b/src/hac/BKTREncryptedStream.cpp
@@ -211,7 +211,7 @@ size_t pie::hac::BKTREncryptedStream::read(byte_t* ptr, size_t count)
 
 size_t pie::hac::BKTREncryptedStream::write(const byte_t* ptr, size_t count)
 {
-	throw tc::NotImplementedException(kClassName+"::write()", "write is not implemented for BKTREncryptedStream");
+	throw tc::NotSupportedException(kClassName+"::write()", "write is not supported for BKTREncryptedStream");
 }
 
 int64_t pie::hac::BKTREncryptedStream::seek(int64_t offset, tc::io::SeekOrigin origin)
@@ -221,7 +221,7 @@ int64_t pie::hac::BKTREncryptedStream::seek(int64_t offset, tc::io::SeekOrigin o
 
 void pie::hac::BKTREncryptedStream::setLength(int64_t length)
 {
-	throw tc::NotImplementedException(kClassName+"::setLength()", "setLength is not implemented for BKTREncryptedStream");
+	throw tc::NotSupportedException(kClassName+"::setLength()", "setLength is not supported for BKTREncryptedStream");
 }
 
 void pie::hac::BKTREncryptedStream::flush()

--- a/src/hac/BKTRSubsectionEncryptedStream.cpp
+++ b/src/hac/BKTRSubsectionEncryptedStream.cpp
@@ -179,7 +179,7 @@ size_t pie::hac::BKTRSubsectionEncryptedStream::read(byte_t* ptr, size_t count)
 
 size_t pie::hac::BKTRSubsectionEncryptedStream::write(const byte_t* ptr, size_t count)
 {
-	throw tc::NotImplementedException(kClassName+"::write()", "write is not implemented for BKTRSubsectionEncryptedStream");
+	throw tc::NotSupportedException(kClassName+"::write()", "write is not supported for BKTRSubsectionEncryptedStream");
 }
 
 int64_t pie::hac::BKTRSubsectionEncryptedStream::seek(int64_t offset, tc::io::SeekOrigin origin)
@@ -189,7 +189,7 @@ int64_t pie::hac::BKTRSubsectionEncryptedStream::seek(int64_t offset, tc::io::Se
 
 void pie::hac::BKTRSubsectionEncryptedStream::setLength(int64_t length)
 {
-	throw tc::NotImplementedException(kClassName+"::setLength()", "setLength is not implemented for BKTRSubsectionEncryptedStream");
+	throw tc::NotSupportedException(kClassName+"::setLength()", "setLength is not supported for BKTRSubsectionEncryptedStream");
 }
 
 void pie::hac::BKTRSubsectionEncryptedStream::flush()

--- a/src/hac/GameCardFsSnapshotGenerator.cpp
+++ b/src/hac/GameCardFsSnapshotGenerator.cpp
@@ -1,7 +1,7 @@
 #include <pietendo/hac/GameCardFsSnapshotGenerator.h>
 #include <tc/io/SubStream.h>
 #include <tc/io/IOUtil.h>
-#include <tc/crypto/Sha256Generator.h>
+#include <tc/crypto/Sha2256Generator.h>
 #include <tc/crypto/CryptoException.h>
 
 #include <pietendo/hac/PartitionFsHeader.h>
@@ -82,7 +82,7 @@ pie::hac::GameCardFsSnapshotGenerator::GameCardFsSnapshotGenerator(const std::sh
 		// validate header if required
 		if (validate_mode == ValidationMode_Warn || validate_mode == ValidationMode_Throw)
 		{
-			tc::crypto::GenerateSha256Hash(calc_hash.data(), part_header_raw.data(), part_header_raw.size());
+			tc::crypto::GenerateSha2256Hash(calc_hash.data(), part_header_raw.data(), part_header_raw.size());
 			if (memcmp(calc_hash.data(), dirItr->hash.data(), calc_hash.size()) != 0)
 			{
 				std::string error_msg = fmt::format("Partition \"{:s}\" failed hash check.", dirItr->name);
@@ -169,7 +169,7 @@ pie::hac::GameCardFsSnapshotGenerator::GameCardFsSnapshotGenerator(const std::sh
 				stream->seek(fileItr->offset, tc::io::SeekOrigin::Begin);
 				stream->read(tmp_data.data(), tmp_data.size());
 
-				tc::crypto::GenerateSha256Hash(calc_hash.data(), tmp_data.data(), tmp_data.size());
+				tc::crypto::GenerateSha2256Hash(calc_hash.data(), tmp_data.data(), tmp_data.size());
 				if (memcmp(calc_hash.data(), fileItr->hash.data(), calc_hash.size()) != 0)
 				{
 					std::string error_msg = fmt::format("\"{:s}\" failed hash check.", fileItr->name);

--- a/src/hac/HierarchicalIntegrityStream.cpp
+++ b/src/hac/HierarchicalIntegrityStream.cpp
@@ -299,7 +299,7 @@ size_t pie::hac::HierarchicalIntegrityStream::read(byte_t* ptr, size_t count)
 
 size_t pie::hac::HierarchicalIntegrityStream::write(const byte_t* ptr, size_t count)
 {
-	throw tc::NotImplementedException(mModuleLabel+"::write()", "write is not supported for HierarchicalIntegrityStream");
+	throw tc::NotSupportedException(mModuleLabel+"::write()", "write is not supported for HierarchicalIntegrityStream");
 }
 
 int64_t pie::hac::HierarchicalIntegrityStream::seek(int64_t offset, tc::io::SeekOrigin origin)

--- a/src/hac/HierarchicalIntegrityStream.cpp
+++ b/src/hac/HierarchicalIntegrityStream.cpp
@@ -13,7 +13,7 @@ pie::hac::HierarchicalIntegrityStream::HierarchicalIntegrityStream() :
 	mDataStreamLogicalLength(0),
 	mDataStream(),
 	mHashCache(),
-	mHashCalc(new tc::crypto::Sha256Generator())
+	mHashCalc(new tc::crypto::Sha2256Generator())
 {
 }
 

--- a/src/hac/HierarchicalSha256Stream.cpp
+++ b/src/hac/HierarchicalSha256Stream.cpp
@@ -284,7 +284,7 @@ size_t pie::hac::HierarchicalSha256Stream::read(byte_t* ptr, size_t count)
 
 size_t pie::hac::HierarchicalSha256Stream::write(const byte_t* ptr, size_t count)
 {
-	throw tc::NotImplementedException(mModuleLabel+"::write()", "write is not supported for HierarchicalSha256Stream");
+	throw tc::NotSupportedException(mModuleLabel+"::write()", "write is not supported for HierarchicalSha256Stream");
 }
 
 int64_t pie::hac::HierarchicalSha256Stream::seek(int64_t offset, tc::io::SeekOrigin origin)

--- a/src/hac/HierarchicalSha256Stream.cpp
+++ b/src/hac/HierarchicalSha256Stream.cpp
@@ -13,7 +13,7 @@ pie::hac::HierarchicalSha256Stream::HierarchicalSha256Stream() :
 	mDataStreamLogicalLength(0),
 	mDataStream(),
 	mHashCache(),
-	mHashCalc(new tc::crypto::Sha256Generator())
+	mHashCalc(new tc::crypto::Sha2256Generator())
 {
 }
 

--- a/src/hac/PartitionFsSnapshotGenerator.cpp
+++ b/src/hac/PartitionFsSnapshotGenerator.cpp
@@ -1,7 +1,7 @@
 #include <pietendo/hac/PartitionFsSnapshotGenerator.h>
 #include <tc/io/SubStream.h>
 #include <tc/io/IOUtil.h>
-#include <tc/crypto/Sha256Generator.h>
+#include <tc/crypto/Sha2256Generator.h>
 #include <tc/crypto/CryptoException.h>
 
 #include <pietendo/hac/define/pfs.h>
@@ -125,7 +125,7 @@ pie::hac::PartitionFsSnapshotGenerator::PartitionFsSnapshotGenerator(const std::
 	dir_entry_path_map[tc::io::Path("/")] = dir_entries.size()-1;
 
 	// populate virtual filesystem
-	std::array<byte_t, tc::crypto::Sha256Generator::kHashSize> hash_tmp;
+	std::array<byte_t, tc::crypto::Sha2256Generator::kHashSize> hash_tmp;
 	for (size_t i = 0; i < section.size(); i++)
 	{
 		if (section[i].size != 0)
@@ -139,7 +139,7 @@ pie::hac::PartitionFsSnapshotGenerator::PartitionFsSnapshotGenerator(const std::
 				stream->seek(section[i].offset, tc::io::SeekOrigin::Begin);
 				stream->read(tmp_data.data(), tmp_data.size());
 
-				tc::crypto::GenerateSha256Hash(hash_tmp.data(), tmp_data.data(), tmp_data.size());
+				tc::crypto::GenerateSha2256Hash(hash_tmp.data(), tmp_data.data(), tmp_data.size());
 				if (memcmp(hash_tmp.data(), section[i].hash.data(), hash_tmp.size()) != 0)
 				{
 					std::string error_msg = fmt::format("\"{:s}\" failed hash check.", section[i].name);

--- a/src/hac/RomFsSnapshotGenerator.cpp
+++ b/src/hac/RomFsSnapshotGenerator.cpp
@@ -2,7 +2,7 @@
 #include <tc/io/SubStream.h>
 #include <tc/io/MemoryStream.h>
 #include <tc/io/IOUtil.h>
-#include <tc/crypto/Sha256Generator.h>
+#include <tc/crypto/Sha2256Generator.h>
 #include <tc/crypto/CryptoException.h>
 
 #include <pietendo/hac/define/romfs.h>

--- a/src/hac/RomFsSnapshotGenerator.cpp
+++ b/src/hac/RomFsSnapshotGenerator.cpp
@@ -1,6 +1,7 @@
 #include <pietendo/hac/RomFsSnapshotGenerator.h>
 #include <tc/io/SubStream.h>
 #include <tc/io/MemoryStream.h>
+#include <tc/io/EmptyStream.h>
 #include <tc/io/IOUtil.h>
 #include <tc/crypto/Sha2256Generator.h>
 #include <tc/crypto/CryptoException.h>
@@ -228,7 +229,10 @@ pie::hac::RomFsSnapshotGenerator::RomFsSnapshotGenerator(const std::shared_ptr<t
 		else
 		{
 			// empty stream
-			file_tmp.stream = std::shared_ptr<tc::io::MemoryStream>(new tc::io::MemoryStream());
+			file_tmp.stream = std::shared_ptr<tc::io::EmptyStream>(new tc::io::EmptyStream());
+			fmt::print("stream properties: canRead()  = {}\n", file_tmp.stream->canRead());
+			fmt::print("stream properties: canWrite() = {}\n", file_tmp.stream->canWrite());
+			fmt::print("stream properties: canSeek()  = {}\n", file_tmp.stream->canSeek());
 		}
 
 		// save file name


### PR DESCRIPTION
# About
This fixes NSTool bug https://github.com/jakcron/nstool/issues/83 (which is actually related to https://github.com/jakcron/nstool/issues/78) where empty RomFs files halt RomFs extraction. It also brings this bug fix and https://github.com/jakcron/nstool/issues/86 to the 3DS RomFs code just in case it gets triggered there too.

# Changes
* Updated `libtoolchain` to `v0.6.1`
* Updated `libfmt` to `v9.0.0`
* Nintendo Switch Library (`pie::hac`)
  * `RomFsSnapshotGenerator`:
    * Fixes https://github.com/jakcron/nstool/issues/83 by using `tc::io::EmptyStream` when populating the FsSnapshot with an empty file.
* Nintendo 3DS Library (`pie::ctr`)
  * `RomFsSnapshotGenerator`:
    * Back port `pie::hac::RomFsSnapshotGenerator` bug fix for https://github.com/jakcron/nstool/issues/83 
    * Back port `pie::hac::RomFsSnapshotGenerator` bug fix for https://github.com/jakcron/nstool/issues/86 