### PR TITLE
libpietendo v0.5.0 Release

### DIFF
--- a/.github/workflows/compile_main_branches.yml
+++ b/.github/workflows/compile_main_branches.yml
@@ -1,10 +1,10 @@
-name: Compile Main Branch
+name: Compile Main Branches
 
 on:
   push:
-    branches: [ main ]
+    branches: [ development-tip, stable ]
   pull_request:
-    branches: [ main ]
+    branches: [ development-tip, stable ]
   release:
     types: [ created ]
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = libpietendo
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = v0.0.0
+PROJECT_NUMBER         = v0.5.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = libpietendo
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = v0.4.0
+PROJECT_NUMBER         = v0.0.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![Platform](https://img.shields.io/badge/platform-linux:%20x86__64,%20i386%20%7C%20windows:%20x86__64,%20i386%20%7C%20macOS:%20x86__64,%20arm64-lightgrey.svg)
 
-![Version](https://img.shields.io/badge/version-0.4.0%20%7C%20prerelease-green.svg)
+![Version](https://img.shields.io/badge/version-0.0.0%20%7C%20prerelease-green.svg)
 
 Library for parsing Nintendo file formats.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![Platform](https://img.shields.io/badge/platform-linux:%20x86__64,%20i386%20%7C%20windows:%20x86__64,%20i386%20%7C%20macOS:%20x86__64,%20arm64-lightgrey.svg)
 
-![Version](https://img.shields.io/badge/version-0.0.0%20%7C%20prerelease-green.svg)
+![Version](https://img.shields.io/badge/version-0.5.0%20%7C%20prerelease-green.svg)
 
 Library for parsing Nintendo file formats.
 

--- a/include/pietendo/hac/define/nca.h
+++ b/include/pietendo/hac/define/nca.h
@@ -54,11 +54,11 @@ namespace nca
 	enum ContentType : byte_t
 	{
 		ContentType_Program = 0,
-		ContentType_Meta = 2,
-		ContentType_Control = 3,
-		ContentType_Manual = 4,
-		ContentType_Data = 5,
-		ContentType_PublicData = 6
+		ContentType_Meta = 1,
+		ContentType_Control = 2,
+		ContentType_Manual = 3,
+		ContentType_Data = 4,
+		ContentType_PublicData = 5
 	};
 
 	enum KeyBankIndex


### PR DESCRIPTION
# About
This release rectifies a typo in an enum.

# Changes
## Additions
N/A
## Changes
* `enum pie::hac::nca::ContentType` had values changed in error during a refactor, this has been corrected:
  * `ContentType_Meta`: `2`->`1`
  * `ContentType_Control`: `3`->`2`
  * `ContentType_Manual`: `4`->`3`
  * `ContentType_Data`: `5`->`4`
  * `ContentType_PublicData`: `6`->`5`
## Bug fixes
N/A
