### PR TITLE
Implement CTR library improvements from Project_CTR

### DIFF
--- a/include/pietendo/ctr/cci.h
+++ b/include/pietendo/ctr/cci.h
@@ -85,10 +85,20 @@ struct NcsdCommonHeader
 
 	struct GameCardExtendedHeader
 	{
+		struct CryptoType
+ 		{
+ 			byte_t enabled : 1;
+ 			byte_t value : 2;
+ 			byte_t reserved : 5;
+ 		};
+
 		// 0x90
 		std::array<tc::bn::le64<uint64_t>, kPartitionNum> partition_id;
 		// 0xD0
-		tc::bn::pad<0x30>                                 reserved;
+		tc::bn::pad<0x2E>                                 reserved;
+ 		// 0xFE
+ 		CryptoType                                        crypto_type;
+ 		byte_t                                            backup_security_version;
 	};
 
 	struct NandExtendedHeader

--- a/src/ctr/ExeFsSnapshotGenerator.cpp
+++ b/src/ctr/ExeFsSnapshotGenerator.cpp
@@ -33,7 +33,7 @@ pie::ctr::ExeFsSnapshotGenerator::ExeFsSnapshotGenerator(const std::shared_ptr<t
 	stream->seek(0, tc::io::SeekOrigin::Begin);
 	stream->read((byte_t*)(&hdr), sizeof(pie::ctr::ExeFsHeader));
 
-	if (hdr.file_table[0].name[0] == 0 || hdr.file_table[0].offset.unwrap() != 0 || hdr.hash_table[pie::ctr::ExeFsHeader::kFileNum - 1][0] == 0)
+	if (hdr.file_table[0].name[0] == 0 || hdr.file_table[0].offset.unwrap() != 0)
 	{
 		throw tc::ArgumentOutOfRangeException("pie::ctr::ExeFsSnapshotGenerator", "ExeFsHeader is corrupted (Bad first entry).");
 	}


### PR DESCRIPTION
This addresses #13 by bringing forward some bug fixes and enhancements from the older libnintendo-n3ds in Project_CTR