### PR TITLE
libpietendo v0.6.0 Release

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = libpietendo
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = v0.0.0
+PROJECT_NUMBER         = v0.6.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/include/pietendo/ctr/cci.h
+++ b/include/pietendo/ctr/cci.h
@@ -85,10 +85,20 @@ struct NcsdCommonHeader
 
 	struct GameCardExtendedHeader
 	{
+		struct CryptoType
+ 		{
+ 			byte_t enabled : 1;
+ 			byte_t value : 2;
+ 			byte_t reserved : 5;
+ 		};
+
 		// 0x90
 		std::array<tc::bn::le64<uint64_t>, kPartitionNum> partition_id;
 		// 0xD0
-		tc::bn::pad<0x30>                                 reserved;
+		tc::bn::pad<0x2E>                                 reserved;
+ 		// 0xFE
+ 		CryptoType                                        crypto_type;
+ 		byte_t                                            backup_security_version;
 	};
 
 	struct NandExtendedHeader

--- a/src/ctr/ExeFsSnapshotGenerator.cpp
+++ b/src/ctr/ExeFsSnapshotGenerator.cpp
@@ -33,7 +33,7 @@ pie::ctr::ExeFsSnapshotGenerator::ExeFsSnapshotGenerator(const std::shared_ptr<t
 	stream->seek(0, tc::io::SeekOrigin::Begin);
 	stream->read((byte_t*)(&hdr), sizeof(pie::ctr::ExeFsHeader));
 
-	if (hdr.file_table[0].name[0] == 0 || hdr.file_table[0].offset.unwrap() != 0 || hdr.hash_table[pie::ctr::ExeFsHeader::kFileNum - 1][0] == 0)
+	if (hdr.file_table[0].name[0] == 0 || hdr.file_table[0].offset.unwrap() != 0)
 	{
 		throw tc::ArgumentOutOfRangeException("pie::ctr::ExeFsSnapshotGenerator", "ExeFsHeader is corrupted (Bad first entry).");
 	}

--- a/src/hac/NsoHeader.cpp
+++ b/src/hac/NsoHeader.cpp
@@ -174,8 +174,8 @@ void pie::hac::NsoHeader::fromBytes(const byte_t* data, size_t len)
 	mDataSegmentInfo.file_layout.size = hdr->data_file_size.unwrap();
 	mDataSegmentInfo.memory_layout.offset = hdr->data.memory_offset.unwrap();
 	mDataSegmentInfo.memory_layout.size = hdr->data.size.unwrap();
-	mDataSegmentInfo.is_compressed = hdr->flags.test((size_t)nso::HeaderFlags_RoCompress);
-	mDataSegmentInfo.is_hashed = hdr->flags.test((size_t)nso::HeaderFlags_RoHash);
+	mDataSegmentInfo.is_compressed = hdr->flags.test((size_t)nso::HeaderFlags_DataCompress);
+	mDataSegmentInfo.is_hashed = hdr->flags.test((size_t)nso::HeaderFlags_DataHash);
 	mDataSegmentInfo.hash = hdr->data_hash;
 
 	mModuleNameInfo.offset = hdr->module_name_offset.unwrap();


### PR DESCRIPTION
# About
This release brings forward some bug-fixes made to Project_CTR.

* Update for 9.6 CCI changes by @liamadvance in https://github.com/3DSGuy/Project_CTR/pull/135
* Remove incorrect ExeFS header hash validation. by @Steveice10 in https://github.com/3DSGuy/Project_CTR/pull/137

# Changes
## Additions
* `pie::ctr::NcsdCommonHeader::GameCardExtendedHeader` was updated to support fw9.6 CCI changes
  * At the end of the header, `crypto_type` and `backup_security_version` were added.
## Changes
N/A
## Bug fixes
* Fixes an issue in `pie::ctr::ExeFsSnapshotGenerator` where ExeFs binaries would be recognised as invalid if the header hash for file[0] started with byte `0x00`.

