### PR TITLE
libpietendo v0.7.0 Release

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = libpietendo
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = v0.0.0
+PROJECT_NUMBER         = v0.7.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/DoxygenMainpage.md
+++ b/DoxygenMainpage.md
@@ -1,3 +1,3 @@
-# libpietendo - API Reference	{#mainpage}
+# libpietendo - API Reference {#mainpage}
 Notice: __This API is currently under development and is subject to change without notice.__
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![Platform](https://img.shields.io/badge/platform-linux:%20x86__64,%20i386%20%7C%20windows:%20x86__64,%20i386%20%7C%20macOS:%20x86__64,%20arm64-lightgrey.svg)
 
-![Version](https://img.shields.io/badge/version-0.0.0%20%7C%20prerelease-green.svg)
+![Version](https://img.shields.io/badge/version-0.7.0%20%7C%20prerelease-green.svg)
 
 Library for parsing Nintendo file formats.
 

--- a/include/pietendo/hac/define/gc.h
+++ b/include/pietendo/hac/define/gc.h
@@ -25,6 +25,7 @@ namespace gc
 	static const uint32_t kCertAreaPageCount = 64;
 	static const uint32_t kNormalAreaStartPageAddress = kReservedAreaPageCount + kCertAreaPageCount + kCardHeaderPageCount + kCardKeyAreaPageCount;
 	*/
+	using gc_page_t = std::array<byte_t, kPageSize>;
 	using upp_hash_t = std::array<byte_t, kUppHashLen>;
 
 	const std::string kUpdatePartitionStr = "update"; 
@@ -80,12 +81,6 @@ namespace gc
 }
 
 #pragma pack(push,1)
-
-struct sGcPage
-{
-	byte_t data[gc::kPageSize];
-};
-static_assert(sizeof(sGcPage) == gc::kPageSize, "sGcPage size.");
 
 struct sGcHeader
 {
@@ -147,12 +142,12 @@ static_assert(sizeof(sGcInitialData) == 0x3C, "sGcInitialData size.");
 struct sGcKeyDataRegion
 {
 	union {
-		std::array<sGcPage, 1> raw_page;
+		std::array<gc::gc_page_t, 1> raw_page;
 		sGcInitialData initial_data; // AES128-CCM encrypted {titlekey[16]}
 	} initial_data_region;
 
 	union {
-		std::array<sGcPage, 6> raw_pages;
+		std::array<gc::gc_page_t, 6> raw_pages;
 		struct {
 			std::array<byte_t, gc::kPageSize * 6> encrypted_data; // AES128-CTR encrypted {titlekey[16]}
 		} enc;
@@ -162,7 +157,7 @@ struct sGcKeyDataRegion
 	} title_key_region;
 	
 	union {
-		std::array<sGcPage, 1> raw_page;
+		std::array<gc::gc_page_t, 1> raw_page;
 		struct {
 			detail::rsa2048_block_t encrypted_data; // RSA2048-OAEP-SHA256 encrypted AES-CTR data used for encrypted_00 {key[16],iv[16]}
 		} enc;

--- a/include/pietendo/hac/define/nacp.h
+++ b/include/pietendo/hac/define/nacp.h
@@ -147,7 +147,7 @@ namespace nacp
 		PlayLogPolicy_LogOnly = 1,
 		PlayLogPolicy_None = 2,
 		PlayLogPolicy_Closed = 3,
-		PlayLogPolicy_All = 0
+		PlayLogPolicy_All = 0 // legacy value
 	};
 
 	enum PlayLogQueryCapability : byte_t

--- a/src/ctr/CciFsSnapshotGenerator.cpp
+++ b/src/ctr/CciFsSnapshotGenerator.cpp
@@ -4,9 +4,7 @@
 
 #include <pietendo/ctr/cci.h>
 
-#include <iostream>
-#include <iomanip>
-#include <sstream>
+#include <fmt/format.h>
 #include <tc/cli/FormatUtil.h>
 
 
@@ -100,13 +98,9 @@ pie::ctr::CciFsShapshotGenerator::CciFsShapshotGenerator(const std::shared_ptr<t
 	{
 		if (partition[i].size != 0)
 		{
-			std::stringstream ss;
-			ss << std::hex << std::setfill('0') << std::setw(2) << i;
-			ss << "_";
-			ss << std::hex << std::setfill('0') << std::setw(16) << partition[i].title_id;
-			ss << ".app";
+			std::string partition_file_name = fmt::format("{:02x}_{:016x}.app", i, partition[i].title_id);
 
-			addFile(ss.str(), partition[i].offset, partition[i].size);
+			addFile(partition_file_name, partition[i].offset, partition[i].size);
 		}
 	}
 }

--- a/src/ctr/CiaFsSnapshotGenerator.cpp
+++ b/src/ctr/CiaFsSnapshotGenerator.cpp
@@ -5,9 +5,7 @@
 #include <pietendo/ctr/cia.h>
 #include <pietendo/es/tmd.h>
 
-#include <iostream>
-#include <iomanip>
-#include <sstream>
+#include <fmt/format.h>
 #include <tc/cli/FormatUtil.h>
 
 
@@ -201,12 +199,11 @@ pie::ctr::CiaFsSnapshotGenerator::CiaFsSnapshotGenerator(const std::shared_ptr<t
 				*/
 				if (hdr.content_bitarray.test(tmd->contents[i].index.unwrap()))				
 				{
-					std::stringstream ss;
-					ss << std::hex << std::setfill('0') << std::setw(8) << tmd->contents[i].cid.unwrap() << ".app";
+					std::string content_file_name = fmt::format("{:08x}.app", i, tmd->contents[i].cid.unwrap());
 
 					int64_t content_size = align<int64_t>(tmd->contents[i].size.unwrap(), CiaHeader::kCiaContentAlignment);
 
-					addFile(ss.str(), section[Content].offset + content_offset, content_size);
+					addFile(content_file_name, section[Content].offset + content_offset, content_size);
 					
 					content_offset += content_size;
 				}

--- a/src/hac/AccessControlInfoUtil.cpp
+++ b/src/hac/AccessControlInfoUtil.cpp
@@ -1,29 +1,28 @@
 #include <pietendo/hac/AccessControlInfoUtil.h>
-#include <sstream>
-#include <iomanip>
+#include <fmt/format.h>
 
 std::string pie::hac::AccessControlInfoUtil::getMemoryRegionAsString(pie::hac::aci::MemoryRegion mem_region)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch(mem_region)
 	{
 	case (pie::hac::aci::MemoryRegion_Application):
-		ss << "Application";
+		str = "Application";
 		break;
 	case (pie::hac::aci::MemoryRegion_Applet):
-		ss << "Applet";
+		str = "Applet";
 		break;
 	case (pie::hac::aci::MemoryRegion_SecureSystem):
-		ss << "SecureSystem";
+		str = "SecureSystem";
 		break;
 	case (pie::hac::aci::MemoryRegion_NonSecureSystem):
-		ss << "NonSecureSystem";
+		str = "NonSecureSystem";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << (uint32_t)mem_region;
+		str = fmt::format("unk_0x{:x}", (uint32_t)mem_region);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }

--- a/src/hac/ApplicationControlPropertyUtil.cpp
+++ b/src/hac/ApplicationControlPropertyUtil.cpp
@@ -1,6 +1,5 @@
 #include <pietendo/hac/ApplicationControlPropertyUtil.h>
-#include <sstream>
-#include <iomanip>
+#include <fmt/format.h>
 
 bool pie::hac::ApplicationControlPropertyUtil::validateSaveDataSizeMax(int64_t size, int64_t alignment)
 {
@@ -17,602 +16,602 @@ std::string pie::hac::ApplicationControlPropertyUtil::getSaveDataSizeAsString(in
 	static const int64_t kKiloByte = 1024;
 	static const int64_t kMegaByte = 1024 * 1024;
 
-	std::stringstream ss;
+	std::string str;
 
 
 	if (size < kKiloByte)
 	{
-		ss << size << " B";
+		str = fmt::format("{:d} B", size);
 	}
 	else if (size < kMegaByte)
 	{
-		ss << (size/kKiloByte) << " KiB";
+		str = fmt::format("{:d} KiB", (size/kKiloByte));
 	}
 	else
 	{
-		ss << (size/kMegaByte) << " MiB";
+		str = fmt::format("{:d} MiB", (size/kMegaByte));
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getAddOnContentRegistrationTypeAsString(pie::hac::nacp::AddOnContentRegistrationType val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::AddOnContentRegistrationType_AllOnLaunch):
-		ss << "AllOnLaunch";
+		str = "AllOnLaunch";
 		break;
 	case (pie::hac::nacp::AddOnContentRegistrationType_OnDemand):
-		ss << "OnDemand";
+		str = "OnDemand";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getAttributeFlagAsString(pie::hac::nacp::AttributeFlag val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::AttributeFlag_Demo):
-		ss << "Demo";
+		str = "Demo";
 		break;
 	case (pie::hac::nacp::AttributeFlag_RetailInteractiveDisplay):
-		ss << "RetailInteractiveDisplay";
+		str = "RetailInteractiveDisplay";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getCrashReportAsString(pie::hac::nacp::CrashReport val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::CrashReport_Deny):
-		ss << "Deny";
+		str = "Deny";
 		break;
 	case (pie::hac::nacp::CrashReport_Allow):
-		ss << "Allow";
+		str = "Allow";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getCrashScreenshotForDevAsString(pie::hac::nacp::CrashScreenshotForDev val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::CrashScreenshotForDev_Deny):
-		ss << "Deny";
+		str = "Deny";
 		break;
 	case (pie::hac::nacp::CrashScreenshotForDev_Allow):
-		ss << "Allow";
+		str = "Allow";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getCrashScreenshotForProdAsString(pie::hac::nacp::CrashScreenshotForProd val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::CrashScreenshotForProd_Deny):
-		ss << "Deny";
+		str = "Deny";
 		break;
 	case (pie::hac::nacp::CrashScreenshotForProd_Allow):
-		ss << "Allow";
+		str = "Allow";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getDataLossConfirmationAsString(pie::hac::nacp::DataLossConfirmation val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::DataLossConfirmation_None):
-		ss << "None";
+		str = "None";
 		break;
 	case (pie::hac::nacp::DataLossConfirmation_Required):
-		ss << "Required";
+		str = "Required";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getHdcpAsString(pie::hac::nacp::Hdcp val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::Hdcp_None):
-		ss << "None";
+		str = "None";
 		break;
 	case (pie::hac::nacp::Hdcp_Required):
-		ss << "Required";
+		str = "Required";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getJitConfigurationFlagAsString(pie::hac::nacp::JitConfigurationFlag val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::JitConfigurationFlag_Enabled):
-		ss << "Enabled";
+		str = "Enabled";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(8) << std::setfill('0') << (uint64_t)val;
+		str = fmt::format("unk_0x{:08x}", (uint64_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getLanguageAsString(pie::hac::nacp::Language val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::Language_AmericanEnglish):
-		ss << "AmericanEnglish";
+		str = "AmericanEnglish";
 		break;
 	case (pie::hac::nacp::Language_BritishEnglish):
-		ss << "BritishEnglish";
+		str = "BritishEnglish";
 		break;
 	case (pie::hac::nacp::Language_Japanese):
-		ss << "Japanese";
+		str = "Japanese";
 		break;
 	case (pie::hac::nacp::Language_French):
-		ss << "French";
+		str = "French";
 		break;
 	case (pie::hac::nacp::Language_German):
-		ss << "German";
+		str = "German";
 		break;
 	case (pie::hac::nacp::Language_LatinAmericanSpanish):
-		ss << "LatinAmericanSpanish";
+		str = "LatinAmericanSpanish";
 		break;
 	case (pie::hac::nacp::Language_Spanish):
-		ss << "Spanish";
+		str = "Spanish";
 		break;
 	case (pie::hac::nacp::Language_Italian):
-		ss << "Italian";
+		str = "Italian";
 		break;
 	case (pie::hac::nacp::Language_Dutch):
-		ss << "Dutch";
+		str = "Dutch";
 		break;
 	case (pie::hac::nacp::Language_CanadianFrench):
-		ss << "CanadianFrench";
+		str = "CanadianFrench";
 		break;
 	case (pie::hac::nacp::Language_Portuguese):
-		ss << "Portuguese";
+		str = "Portuguese";
 		break;
 	case (pie::hac::nacp::Language_Russian):
-		ss << "Russian";
+		str = "Russian";
 		break;
 	case (pie::hac::nacp::Language_Korean):
-		ss << "Korean";
+		str = "Korean";
 		break;
 	case (pie::hac::nacp::Language_TraditionalChinese):
-		ss << "TraditionalChinese";
+		str = "TraditionalChinese";
 		break;
 	case (pie::hac::nacp::Language_SimplifiedChinese):
-		ss << "SimplifiedChinese";
+		str = "SimplifiedChinese";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getLogoHandlingAsString(pie::hac::nacp::LogoHandling val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::LogoHandling_Auto):
-		ss << "Auto";
+		str = "Auto";
 		break;
 	case (pie::hac::nacp::LogoHandling_None):
-		ss << "None";
+		str = "None";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getLogoTypeAsString(pie::hac::nacp::LogoType val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::LogoType_LicensedByNintendo):
-		ss << "LicensedByNintendo";
+		str = "LicensedByNintendo";
 		break;
 	case (pie::hac::nacp::LogoType_DistributedByNintendo):
-		ss << "DistributedByNintendo";
+		str = "DistributedByNintendo";
 		break;
 	case (pie::hac::nacp::LogoType_Nintendo):
-		ss << "Nintendo";
+		str = "Nintendo";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getOrganisationAsString(pie::hac::nacp::Organisation val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::Organisation_CERO):
-		ss << "CERO";
+		str = "CERO";
 		break;
 	case (pie::hac::nacp::Organisation_GRACGCRB):
-		ss << "GRACGCRB";
+		str = "GRACGCRB";
 		break;
 	case (pie::hac::nacp::Organisation_GSRMR):
-		ss << "GSRMR";
+		str = "GSRMR";
 		break;
 	case (pie::hac::nacp::Organisation_ESRB):
-		ss << "ESRB";
+		str = "ESRB";
 		break;
 	case (pie::hac::nacp::Organisation_ClassInd):
-		ss << "ClassInd";
+		str = "ClassInd";
 		break;
 	case (pie::hac::nacp::Organisation_USK):
-		ss << "USK";
+		str = "USK";
 		break;
 	case (pie::hac::nacp::Organisation_PEGI):
-		ss << "PEGI";
+		str = "PEGI";
 		break;
 	case (pie::hac::nacp::Organisation_PEGIPortugal):
-		ss << "PEGIPortugal";
+		str = "PEGIPortugal";
 		break;
 	case (pie::hac::nacp::Organisation_PEGIBBFC):
-		ss << "PEGIBBFC";
+		str = "PEGIBBFC";
 		break;
 	case (pie::hac::nacp::Organisation_Russian):
-		ss << "Russian";
+		str = "Russian";
 		break;
 	case (pie::hac::nacp::Organisation_ACB):
-		ss << "ACB";
+		str = "ACB";
 		break;
 	case (pie::hac::nacp::Organisation_OFLC):
-		ss << "OFLC";
+		str = "OFLC";
 		break;
 	case (pie::hac::nacp::Organisation_IARCGeneric):
-		ss << "IARCGeneric";
+		str = "IARCGeneric";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getParentalControlFlagAsString(pie::hac::nacp::ParentalControlFlag val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::ParentalControlFlag_FreeCommunication):
-		ss << "FreeCommunication";
+		str = "FreeCommunication";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getPlayLogPolicyAsString(pie::hac::nacp::PlayLogPolicy val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::PlayLogPolicy_Open):
-		ss << "Open";
+		str = "Open";
 		break;
 	case (pie::hac::nacp::PlayLogPolicy_LogOnly):
-		ss << "LogOnly";
+		str = "LogOnly";
 		break;
 	case (pie::hac::nacp::PlayLogPolicy_None):
-		ss << "None";
+		str = "None";
 		break;
 	case (pie::hac::nacp::PlayLogPolicy_Closed):
-		ss << "Closed";
+		str = "Closed";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getPlayLogQueryCapabilityAsString(pie::hac::nacp::PlayLogQueryCapability val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::PlayLogQueryCapability_None):
-		ss << "None";
+		str = "None";
 		break;
 	case (pie::hac::nacp::PlayLogQueryCapability_Whitelist):
-		ss << "Whitelist";
+		str = "Whitelist";
 		break;
 	case (pie::hac::nacp::PlayLogQueryCapability_All):
-		ss << "All";
+		str = "All";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getPlayReportPermissionAsString(pie::hac::nacp::PlayReportPermission val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::PlayReportPermission_None):
-		ss << "None";
+		str = "None";
 		break;
 	case (pie::hac::nacp::PlayReportPermission_TargetMarketing):
-		ss << "TargetMarketing";
+		str = "TargetMarketing";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getRepairFlagAsString(pie::hac::nacp::RepairFlag val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::RepairFlag_SuppressGameCardAccess):
-		ss << "SuppressGameCardAccess";
+		str = "SuppressGameCardAccess";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getRequiredNetworkServiceLicenseOnLaunchFlagAsString(pie::hac::nacp::RequiredNetworkServiceLicenseOnLaunchFlag val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::RequiredNetworkServiceLicenseOnLaunchFlag_Common):
-		ss << "Common";
+		str = "Common";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getRuntimeAddOnContentInstallAsString(pie::hac::nacp::RuntimeAddOnContentInstall val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::RuntimeAddOnContentInstall_Deny):
-		ss << "Deny";
+		str = "Deny";
 		break;
 	case (pie::hac::nacp::RuntimeAddOnContentInstall_AllowAppend):
-		ss << "AllowAppend";
+		str = "AllowAppend";
 		break;
 	case (pie::hac::nacp::RuntimeAddOnContentInstall_AllowAppendButDontDownloadWhenUsingNetwork):
-		ss << "AllowAppendButDontDownloadWhenUsingNetwork";
+		str = "AllowAppendButDontDownloadWhenUsingNetwork";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getRuntimeParameterDeliveryAsString(pie::hac::nacp::RuntimeParameterDelivery val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::RuntimeParameterDelivery_Always):
-		ss << "Always";
+		str = "Always";
 		break;
 	case (pie::hac::nacp::RuntimeParameterDelivery_AlwaysIfUserStateMatched):
-		ss << "AlwaysIfUserStateMatched";
+		str = "AlwaysIfUserStateMatched";
 		break;
 	case (pie::hac::nacp::RuntimeParameterDelivery_OnRestart):
-		ss << "OnRestart";
+		str = "OnRestart";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getScreenshotAsString(pie::hac::nacp::Screenshot val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::Screenshot_Allow):
-		ss << "Allow";
+		str = "Allow";
 		break;
 	case (pie::hac::nacp::Screenshot_Deny):
-		ss << "Deny";
+		str = "Deny";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getStartupUserAccountAsString(pie::hac::nacp::StartupUserAccount val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::StartupUserAccount_None):
-		ss << "None";
+		str = "None";
 		break;
 	case (pie::hac::nacp::StartupUserAccount_Required):
-		ss << "Required";
+		str = "Required";
 		break;
 	case (pie::hac::nacp::StartupUserAccount_RequiredWithNetworkServiceAccountAvailable):
-		ss << "RequiredWithNetworkServiceAccountAvailable";
+		str = "RequiredWithNetworkServiceAccountAvailable";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getStartupUserAccountOptionFlagAsString(pie::hac::nacp::StartupUserAccountOptionFlag val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::StartupUserAccountOptionFlag_IsOptional):
-		ss << "IsOptional";
+		str = "IsOptional";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getUserAccountSwitchLockAsString(pie::hac::nacp::UserAccountSwitchLock val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::UserAccountSwitchLock_Disable):
-		ss << "Disable";
+		str = "Disable";
 		break;
 	case (pie::hac::nacp::UserAccountSwitchLock_Enable):
-		ss << "Enable";
+		str = "Enable";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ApplicationControlPropertyUtil::getVideoCaptureAsString(pie::hac::nacp::VideoCapture val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nacp::VideoCapture_Disable):
-		ss << "Disable";
+		str = "Disable";
 		break;
 	case (pie::hac::nacp::VideoCapture_Manual):
-		ss << "Manual";
+		str = "Manual";
 		break;
 	case (pie::hac::nacp::VideoCapture_Enable):
-		ss << "Enable";
+		str = "Enable";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }

--- a/src/hac/ApplicationControlPropertyUtil.cpp
+++ b/src/hac/ApplicationControlPropertyUtil.cpp
@@ -243,6 +243,9 @@ std::string pie::hac::ApplicationControlPropertyUtil::getLanguageAsString(pie::h
 	case (pie::hac::nacp::Language_SimplifiedChinese):
 		str = "SimplifiedChinese";
 		break;
+	case (pie::hac::nacp::Language_BrazilianPortuguese):
+		str = "BrazilianPortuguese";
+		break;
 	default:
 		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;

--- a/src/hac/ContentMetaUtil.cpp
+++ b/src/hac/ContentMetaUtil.cpp
@@ -1,197 +1,195 @@
 #include <pietendo/hac/ContentMetaUtil.h>
-#include <sstream>
-#include <iomanip>
+#include <fmt/format.h>
 
 std::string pie::hac::ContentMetaUtil::getContentTypeAsString(pie::hac::cnmt::ContentType val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::cnmt::ContentType_Meta):
-		ss << "Meta";
+		str = "Meta";
 		break;
 	case (pie::hac::cnmt::ContentType_Program):
-		ss << "Program";
+		str = "Program";
 		break;
 	case (pie::hac::cnmt::ContentType_Data):
-		ss << "Data";
+		str = "Data";
 		break;
 	case (pie::hac::cnmt::ContentType_Control):
-		ss << "Control";
+		str = "Control";
 		break;
 	case (pie::hac::cnmt::ContentType_HtmlDocument):
-		ss << "HtmlDocument";
+		str = "HtmlDocument";
 		break;
 	case (pie::hac::cnmt::ContentType_LegalInformation):
-		ss << "LegalInformation";
+		str = "LegalInformation";
 		break;
 	case (pie::hac::cnmt::ContentType_DeltaFragment):
-		ss << "DeltaFragment";
+		str = "DeltaFragment";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ContentMetaUtil::getContentMetaTypeAsString(pie::hac::cnmt::ContentMetaType val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::cnmt::ContentMetaType_SystemProgram):
-		ss << "SystemProgram";
+		str = "SystemProgram";
 		break;
 	case (pie::hac::cnmt::ContentMetaType_SystemData):
-		ss << "SystemData";
+		str = "SystemData";
 		break;
 	case (pie::hac::cnmt::ContentMetaType_SystemUpdate):
-		ss << "SystemUpdate";
+		str = "SystemUpdate";
 		break;
 	case (pie::hac::cnmt::ContentMetaType_BootImagePackage):
-		ss << "BootImagePackage";
+		str = "BootImagePackage";
 		break;
 	case (pie::hac::cnmt::ContentMetaType_BootImagePackageSafe):
-		ss << "BootImagePackageSafe";
+		str = "BootImagePackageSafe";
 		break;
 	case (pie::hac::cnmt::ContentMetaType_Application):
-		ss << "Application";
+		str = "Application";
 		break;
 	case (pie::hac::cnmt::ContentMetaType_Patch):
-		ss << "Patch";
+		str = "Patch";
 		break;
 	case (pie::hac::cnmt::ContentMetaType_AddOnContent):
-		ss << "AddOnContent";
+		str = "AddOnContent";
 		break;
 	case (pie::hac::cnmt::ContentMetaType_Delta):
-		ss << "Delta";
+		str = "Delta";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ContentMetaUtil::getUpdateTypeAsString(pie::hac::cnmt::UpdateType val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::cnmt::UpdateType_ApplyAsDelta):
-		ss << "ApplyAsDelta";
+		str = "ApplyAsDelta";
 		break;
 	case (pie::hac::cnmt::UpdateType_Overwrite):
-		ss << "Overwrite";
+		str = "Overwrite";
 		break;
 	case (pie::hac::cnmt::UpdateType_Create):
-		ss << "Create";
+		str = "Create";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ContentMetaUtil::getContentInstallTypeAsString(pie::hac::cnmt::ContentInstallType val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::cnmt::ContentInstallType_Full):
-		ss << "Full";
+		str = "Full";
 		break;
 	case (pie::hac::cnmt::ContentInstallType_FragmentOnly):
-		ss << "FragmentOnly";
+		str = "FragmentOnly";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ContentMetaUtil::getStorageIdAsString(pie::hac::cnmt::StorageId val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::cnmt::StorageId_None):
-		ss << "None";
+		str = "None";
 		break;
 	case (pie::hac::cnmt::StorageId_Host):
-		ss << "Host";
+		str = "Host";
 		break;
 	case (pie::hac::cnmt::StorageId_GameCard):
-		ss << "GameCard";
+		str = "GameCard";
 		break;
 	case (pie::hac::cnmt::StorageId_BuiltInSystem):
-		ss << "BuiltInSystem";
+		str = "BuiltInSystem";
 		break;
 	case (pie::hac::cnmt::StorageId_BuiltInUser):
-		ss << "BuiltInUser";
+		str = "BuiltInUser";
 		break;
 	case (pie::hac::cnmt::StorageId_SdCard):
-		ss << "SdCard";
+		str = "SdCard";
 		break;
 	case (pie::hac::cnmt::StorageId_Any):
-		ss << "Any";
+		str = "Any";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ContentMetaUtil::getContentMetaAttributeFlagAsString(pie::hac::cnmt::ContentMetaAttributeFlag val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::cnmt::ContentMetaAttributeFlag_IncludesExFatDriver):
-		ss << "IncludesExFatDriver";
+		str = "IncludesExFatDriver";
 		break;
 	case (pie::hac::cnmt::ContentMetaAttributeFlag_Rebootless):
-		ss << "Rebootless";
+		str = "Rebootless";
 		break;
 	case (pie::hac::cnmt::ContentMetaAttributeFlag_Compacted):
-		ss << "Compacted";
+		str = "Compacted";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::ContentMetaUtil::getVersionAsString(uint32_t version)
 {
-	std::stringstream ss;
+	std::string str;
 
-	ss << (uint32_t)((version>>26) & 0x3f);
-	ss << ".";
-	ss << (uint32_t)((version>>20) & 0x3f);
-	ss << ".";
-	ss << (uint32_t)((version>>16) & 0xf);
-	ss << "-";
-	ss << (uint32_t)((version>>8) & 0xff);
-	ss << ".";
-	ss << (uint32_t)((version>>0) & 0xff);
+	uint32_t major,minor,micro,patch_major,patch_minor;
+	major = (uint32_t)((version>>26) & 0x3f);
+	minor = (uint32_t)((version>>20) & 0x3f);
+	micro = (uint32_t)((version>>16) & 0xf);
+	patch_major = (uint32_t)((version>>8) & 0xff);
+	patch_minor = (uint32_t)((version>>0) & 0xff);
 
-	return ss.str();
+	str = fmt::format("{:d}.{:d}.{:d}-{:d}.{:d}", major,minor,micro,patch_major,patch_minor);
+
+	return str;
 }

--- a/src/hac/FileSystemAccessUtil.cpp
+++ b/src/hac/FileSystemAccessUtil.cpp
@@ -1,154 +1,153 @@
 #include <pietendo/hac/FileSystemAccessUtil.h>
-#include <sstream>
-#include <iomanip>
+#include <fmt/format.h>
 
 std::string pie::hac::FileSystemAccessUtil::getFsAccessFlagAsString(pie::hac::fac::FsAccessFlag flag)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch(flag)
 	{
 	case (pie::hac::fac::FsAccessFlag_ApplicationInfo):
-		ss << "ApplicationInfo";
+		str = "ApplicationInfo";
 		break;
 	case (pie::hac::fac::FsAccessFlag_BootModeControl):
-		ss << "BootModeControl";
+		str = "BootModeControl";
 		break;
 	case (pie::hac::fac::FsAccessFlag_Calibration):
-		ss << "Calibration";
+		str = "Calibration";
 		break;
 	case (pie::hac::fac::FsAccessFlag_SystemSaveData):
-		ss << "SystemSaveData";
+		str = "SystemSaveData";
 		break;
 	case (pie::hac::fac::FsAccessFlag_GameCard):
-		ss << "GameCard";
+		str = "GameCard";
 		break;
 	case (pie::hac::fac::FsAccessFlag_SaveDataBackUp):
-		ss << "SaveDataBackUp";
+		str = "SaveDataBackUp";
 		break;
 	case (pie::hac::fac::FsAccessFlag_SaveDataManagement):
-		ss << "SaveDataManagement";
+		str = "SaveDataManagement";
 		break;
 	case (pie::hac::fac::FsAccessFlag_BisAllRaw):
-		ss << "BisAllRaw";
+		str = "BisAllRaw";
 		break;
 	case (pie::hac::fac::FsAccessFlag_GameCardRaw):
-		ss << "GameCardRaw";
+		str = "GameCardRaw";
 		break;
 	case (pie::hac::fac::FsAccessFlag_GameCardPrivate):
-		ss << "GameCardPrivate";
+		str = "GameCardPrivate";
 		break;
 	case (pie::hac::fac::FsAccessFlag_SetTime):
-		ss << "SetTime";
+		str = "SetTime";
 		break;
 	case (pie::hac::fac::FsAccessFlag_ContentManager):
-		ss << "ContentManager";
+		str = "ContentManager";
 		break;
 	case (pie::hac::fac::FsAccessFlag_ImageManager):
-		ss << "ImageManager";
+		str = "ImageManager";
 		break;
 	case (pie::hac::fac::FsAccessFlag_CreateSaveData):
-		ss << "CreateSaveData";
+		str = "CreateSaveData";
 		break;
 	case (pie::hac::fac::FsAccessFlag_SystemSaveDataManagement):
-		ss << "SystemSaveDataManagement";
+		str = "SystemSaveDataManagement";
 		break;
 	case (pie::hac::fac::FsAccessFlag_BisFileSystem):
-		ss << "BisFileSystem";
+		str = "BisFileSystem";
 		break;
 	case (pie::hac::fac::FsAccessFlag_SystemUpdate):
-		ss << "SystemUpdate";
+		str = "SystemUpdate";
 		break;
 	case (pie::hac::fac::FsAccessFlag_SaveDataMeta):
-		ss << "SaveDataMeta";
+		str = "SaveDataMeta";
 		break;
 	case (pie::hac::fac::FsAccessFlag_DeviceSaveData):
-		ss << "DeviceSaveData";
+		str = "DeviceSaveData";
 		break;
 	case (pie::hac::fac::FsAccessFlag_SettingsControl):
-		ss << "SettingsControl";
+		str = "SettingsControl";
 		break;
 	case (pie::hac::fac::FsAccessFlag_SystemData):
-		ss << "SystemData";
+		str = "SystemData";
 		break;
 	case (pie::hac::fac::FsAccessFlag_SdCard):
-		ss << "SdCard";
+		str = "SdCard";
 		break;
 	case (pie::hac::fac::FsAccessFlag_Host):
-		ss << "Host";
+		str = "Host";
 		break;
 	case (pie::hac::fac::FsAccessFlag_FillBis):
-		ss << "FillBis";
+		str = "FillBis";
 		break;
 	case (pie::hac::fac::FsAccessFlag_CorruptSaveData):
-		ss << "CorruptSaveData";
+		str = "CorruptSaveData";
 		break;
 	case (pie::hac::fac::FsAccessFlag_SaveDataForDebug):
-		ss << "SaveDataForDebug";
+		str = "SaveDataForDebug";
 		break;
 	case (pie::hac::fac::FsAccessFlag_FormatSdCard):
-		ss << "FormatSdCard";
+		str = "FormatSdCard";
 		break;
 	case (pie::hac::fac::FsAccessFlag_GetRightsId):
-		ss << "GetRightsId";
+		str = "GetRightsId";
 		break;
 	case (pie::hac::fac::FsAccessFlag_RegisterExternalKey):
-		ss << "RegisterExternalKey";
+		str = "RegisterExternalKey";
 		break;
 	case (pie::hac::fac::FsAccessFlag_RegisterUpdatePartition):
-		ss << "RegisterUpdatePartition";
+		str = "RegisterUpdatePartition";
 		break;
 	case (pie::hac::fac::FsAccessFlag_SaveDataTransfer):
-		ss << "SaveDataTransfer";
+		str = "SaveDataTransfer";
 		break;
 	case (pie::hac::fac::FsAccessFlag_DeviceDetection):
-		ss << "DeviceDetection";
+		str = "DeviceDetection";
 		break;
 	case (pie::hac::fac::FsAccessFlag_AccessFailureResolution):
-		ss << "AccessFailureResolution";
+		str = "AccessFailureResolution";
 		break;
 	case (pie::hac::fac::FsAccessFlag_SaveDataTransferVersion2):
-		ss << "SaveDataTransferVersion2";
+		str = "SaveDataTransferVersion2";
 		break;
 	case (pie::hac::fac::FsAccessFlag_RegisterProgramIndexMapInfo):
-		ss << "RegisterProgramIndexMapInfo";
+		str = "RegisterProgramIndexMapInfo";
 		break;
 	case (pie::hac::fac::FsAccessFlag_CreateOwnSaveData):
-		ss << "CreateOwnSaveData";
+		str = "CreateOwnSaveData";
 		break;
 	case (pie::hac::fac::FsAccessFlag_Debug):
-		ss << "Debug";
+		str = "Debug";
 		break;
 	case (pie::hac::fac::FsAccessFlag_FullPermission):
-		ss << "FullPermission";
+		str = "FullPermission";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)flag;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)flag);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::FileSystemAccessUtil::getSaveDataOwnerAccessModeAsString(pie::hac::fac::SaveDataOwnerIdAccessType type)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch(type)
 	{
 	case (pie::hac::fac::SaveDataOwnerIdAccessType_Read):
-		ss << "Read";
+		str = "Read";
 		break;
 	case (pie::hac::fac::SaveDataOwnerIdAccessType_Write):
-		ss << "Write";
+		str = "Write";
 		break;
 	case (pie::hac::fac::SaveDataOwnerIdAccessType_ReadWrite):
-		ss << "ReadWrite";
+		str = "ReadWrite";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)type;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)type);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }

--- a/src/hac/GameCardUtil.cpp
+++ b/src/hac/GameCardUtil.cpp
@@ -1,6 +1,5 @@
 #include <pietendo/hac/GameCardUtil.h>
-#include <sstream>
-#include <iomanip>
+#include <fmt/format.h>
 
 void pie::hac::GameCardUtil::getXciHeaderAesIv(const pie::hac::sGcHeader* hdr, pie::hac::detail::aes_iv_t& iv)
 {
@@ -21,150 +20,150 @@ void pie::hac::GameCardUtil::decryptXciHeader(pie::hac::sGcHeader* hdr, const by
 
 std::string pie::hac::GameCardUtil::getKekIndexAsString(pie::hac::gc::KekIndex val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::gc::KekIndex_Prod):
-		ss << "Production";
+		str = "Production";
 		break;
 	case (pie::hac::gc::KekIndex_Dev):
-		ss << "Development";
+		str = "Development";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::GameCardUtil::getRomSizeAsString(pie::hac::gc::RomSize val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::gc::RomSize_1GB):
-		ss << "1GB";
+		str = "1GB";
 		break;
 	case (pie::hac::gc::RomSize_2GB):
-		ss << "2GB";
+		str = "2GB";
 		break;
 	case (pie::hac::gc::RomSize_4GB):
-		ss << "4GB";
+		str = "4GB";
 		break;
 	case (pie::hac::gc::RomSize_8GB):
-		ss << "8GB";
+		str = "8GB";
 		break;
 	case (pie::hac::gc::RomSize_16GB):
-		ss << "16GB";
+		str = "16GB";
 		break;
 	case (pie::hac::gc::RomSize_32GB):
-		ss << "32GB";
+		str = "32GB";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::GameCardUtil::getHeaderFlagsAsString(pie::hac::gc::HeaderFlags val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::gc::HeaderFlags_AutoBoot):
-		ss << "AutoBoot";
+		str = "AutoBoot";
 		break;
 	case (pie::hac::gc::HeaderFlags_HistoryErase):
-		ss << "HistoryErase";
+		str = "HistoryErase";
 		break;
 	case (pie::hac::gc::HeaderFlags_RepairTimeRevisorTool):
-		ss << "RepairTimeRevisorTool";
+		str = "RepairTimeRevisorTool";
 		break;
 	case (pie::hac::gc::HeaderFlags_AllowCupToChina):
-		ss << "AllowCupToChina";
+		str = "AllowCupToChina";
 		break;
 	case (pie::hac::gc::HeaderFlags_AllowCupToGlobal):
-		ss << "AllowCupToGlobal";
+		str = "AllowCupToGlobal";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::GameCardUtil::getCardFwVersionDescriptionAsString(pie::hac::gc::FwVersion val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::gc::FwVersion_DevKit):
-		ss << "ForDevelopment";
+		str = "ForDevelopment";
 		break;
 	case (pie::hac::gc::FwVersion_Prod):
-		ss << "1.0.0+";
+		str = "1.0.0+";
 		break;
 	case (pie::hac::gc::FwVersion_Prod_Since4_0_0NUP):
-		ss << "4.0.0+";
+		str = "4.0.0+";
 		break;
 	case (pie::hac::gc::FwVersion_Prod_Since11_0_0NUP):
-		ss << "11.0.0+";
+		str = "11.0.0+";
 		break;
 	case (pie::hac::gc::FwVersion_Prod_Since12_0_0NUP):
-		ss << "12.0.0+";
+		str = "12.0.0+";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(16) << std::setfill('0') << (uint64_t)val;
+		str = fmt::format("unk_0x{:016x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::GameCardUtil::getCardClockRateAsString(pie::hac::gc::CardClockRate val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::gc::CardClockRate_25MHz):
-		ss << "20 MHz";
+		str = "20 MHz";
 		break;
 	case (pie::hac::gc::CardClockRate_50MHz):
-		ss << "50 MHz";
+		str = "50 MHz";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(8) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:08x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::GameCardUtil::getCompatibilityTypeAsString(pie::hac::gc::CompatibilityType val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::gc::CompatibilityType_Global):
-		ss << "Global";
+		str = "Global";
 		break;
 	case (pie::hac::gc::CompatibilityType_China):
-		ss << "China";
+		str = "China";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }

--- a/src/hac/KernelCapabilityUtil.cpp
+++ b/src/hac/KernelCapabilityUtil.cpp
@@ -1,484 +1,483 @@
 #include <pietendo/hac/KernelCapabilityUtil.h>
-#include <sstream>
-#include <iomanip>
+#include <fmt/format.h>
 
 std::string pie::hac::KernelCapabilityUtil::getMiscFlagsBitAsString(pie::hac::kc::MiscFlagsBit flag)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch(flag)
 	{
 	case (pie::hac::kc::MiscFlagsBit_EnableDebug):
-		ss << "EnableDebug";
+		str = "EnableDebug";
 		break;
 	case (pie::hac::kc::MiscFlagsBit_ForceDebug):
-		ss << "ForceDebug";
+		str = "ForceDebug";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)flag;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)flag);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::KernelCapabilityUtil::getProgramTypeAsString(pie::hac::kc::ProgramType type)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch(type)
 	{
 	case (pie::hac::kc::ProgramType_System):
-		ss << "System";
+		str = "System";
 		break;
 	case (pie::hac::kc::ProgramType_Application):
-		ss << "Application";
+		str = "Application";
 		break;
 	case (pie::hac::kc::ProgramType_Applet):
-		ss << "Applet";
+		str = "Applet";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)type;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)type);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::KernelCapabilityUtil::getMemoryPermissionAsString(pie::hac::kc::MemoryPermission type)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch(type)
 	{
 	case (pie::hac::kc::MemoryPermission_Rw):
-		ss << "Rw";
+		str = "Rw";
 		break;
 	case (pie::hac::kc::MemoryPermission_Ro):
-		ss << "Ro";
+		str = "Ro";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)type;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)type);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::KernelCapabilityUtil::getMappingTypeAsString(pie::hac::kc::MappingType type)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch(type)
 	{
 	case (pie::hac::kc::MappingType_Io):
-		ss << "Io";
+		str = "Io";
 		break;
 	case (pie::hac::kc::MappingType_Static):
-		ss << "Static";
+		str = "Static";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)type;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)type);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::KernelCapabilityUtil::getSystemCallIdAsString(pie::hac::kc::SystemCallId syscall_id)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch(syscall_id)
 	{
 	case (pie::hac::kc::SystemCallId_Unknown0):
-		ss << "Unknown0";
+		str = "Unknown0";
 		break;
 	case (pie::hac::kc::SystemCallId_SetHeapSize):
-		ss << "SetHeapSize";
+		str = "SetHeapSize";
 		break;
 	case (pie::hac::kc::SystemCallId_SetMemoryPermission):
-		ss << "SetMemoryPermission";
+		str = "SetMemoryPermission";
 		break;
 	case (pie::hac::kc::SystemCallId_SetMemoryAttribute):
-		ss << "SetMemoryAttribute";
+		str = "SetMemoryAttribute";
 		break;
 	case (pie::hac::kc::SystemCallId_MapMemory):
-		ss << "MapMemory";
+		str = "MapMemory";
 		break;
 	case (pie::hac::kc::SystemCallId_UnmapMemory):
-		ss << "UnmapMemory";
+		str = "UnmapMemory";
 		break;
 	case (pie::hac::kc::SystemCallId_QueryMemory):
-		ss << "QueryMemory";
+		str = "QueryMemory";
 		break;
 	case (pie::hac::kc::SystemCallId_ExitProcess):
-		ss << "ExitProcess";
+		str = "ExitProcess";
 		break;
 	case (pie::hac::kc::SystemCallId_CreateThread):
-		ss << "CreateThread";
+		str = "CreateThread";
 		break;
 	case (pie::hac::kc::SystemCallId_StartThread):
-		ss << "StartThread";
+		str = "StartThread";
 		break;
 	case (pie::hac::kc::SystemCallId_ExitThread):
-		ss << "ExitThread";
+		str = "ExitThread";
 		break;
 	case (pie::hac::kc::SystemCallId_SleepThread):
-		ss << "SleepThread";
+		str = "SleepThread";
 		break;
 	case (pie::hac::kc::SystemCallId_GetThreadPriority):
-		ss << "GetThreadPriority";
+		str = "GetThreadPriority";
 		break;
 	case (pie::hac::kc::SystemCallId_SetThreadPriority):
-		ss << "SetThreadPriority";
+		str = "SetThreadPriority";
 		break;
 	case (pie::hac::kc::SystemCallId_GetThreadCoreMask):
-		ss << "GetThreadCoreMask";
+		str = "GetThreadCoreMask";
 		break;
 	case (pie::hac::kc::SystemCallId_SetThreadCoreMask):
-		ss << "SetThreadCoreMask";
+		str = "SetThreadCoreMask";
 		break;
 	case (pie::hac::kc::SystemCallId_GetCurrentProcessorNumber):
-		ss << "GetCurrentProcessorNumber";
+		str = "GetCurrentProcessorNumber";
 		break;
 	case (pie::hac::kc::SystemCallId_SignalEvent):
-		ss << "SignalEvent";
+		str = "SignalEvent";
 		break;
 	case (pie::hac::kc::SystemCallId_ClearEvent):
-		ss << "ClearEvent";
+		str = "ClearEvent";
 		break;
 	case (pie::hac::kc::SystemCallId_MapSharedMemory):
-		ss << "MapSharedMemory";
+		str = "MapSharedMemory";
 		break;
 	case (pie::hac::kc::SystemCallId_UnmapSharedMemory):
-		ss << "UnmapSharedMemory";
+		str = "UnmapSharedMemory";
 		break;
 	case (pie::hac::kc::SystemCallId_CreateTransferMemory):
-		ss << "CreateTransferMemory";
+		str = "CreateTransferMemory";
 		break;
 	case (pie::hac::kc::SystemCallId_CloseHandle):
-		ss << "CloseHandle";
+		str = "CloseHandle";
 		break;
 	case (pie::hac::kc::SystemCallId_ResetSignal):
-		ss << "ResetSignal";
+		str = "ResetSignal";
 		break;
 	case (pie::hac::kc::SystemCallId_WaitSynchronization):
-		ss << "WaitSynchronization";
+		str = "WaitSynchronization";
 		break;
 	case (pie::hac::kc::SystemCallId_CancelSynchronization):
-		ss << "CancelSynchronization";
+		str = "CancelSynchronization";
 		break;
 	case (pie::hac::kc::SystemCallId_ArbitrateLock):
-		ss << "ArbitrateLock";
+		str = "ArbitrateLock";
 		break;
 	case (pie::hac::kc::SystemCallId_ArbitrateUnlock):
-		ss << "ArbitrateUnlock";
+		str = "ArbitrateUnlock";
 		break;
 	case (pie::hac::kc::SystemCallId_WaitProcessWideKeyAtomic):
-		ss << "WaitProcessWideKeyAtomic";
+		str = "WaitProcessWideKeyAtomic";
 		break;
 	case (pie::hac::kc::SystemCallId_SignalProcessWideKey):
-		ss << "SignalProcessWideKey";
+		str = "SignalProcessWideKey";
 		break;
 	case (pie::hac::kc::SystemCallId_GetSystemTick):
-		ss << "GetSystemTick";
+		str = "GetSystemTick";
 		break;
 	case (pie::hac::kc::SystemCallId_ConnectToNamedPort):
-		ss << "ConnectToNamedPort";
+		str = "ConnectToNamedPort";
 		break;
 	case (pie::hac::kc::SystemCallId_SendSyncRequestLight):
-		ss << "SendSyncRequestLight";
+		str = "SendSyncRequestLight";
 		break;
 	case (pie::hac::kc::SystemCallId_SendSyncRequest):
-		ss << "SendSyncRequest";
+		str = "SendSyncRequest";
 		break;
 	case (pie::hac::kc::SystemCallId_SendSyncRequestWithUserBuffer):
-		ss << "SendSyncRequestWithUserBuffer";
+		str = "SendSyncRequestWithUserBuffer";
 		break;
 	case (pie::hac::kc::SystemCallId_SendAsyncRequestWithUserBuffer):
-		ss << "SendAsyncRequestWithUserBuffer";
+		str = "SendAsyncRequestWithUserBuffer";
 		break;
 	case (pie::hac::kc::SystemCallId_GetProcessId):
-		ss << "GetProcessId";
+		str = "GetProcessId";
 		break;
 	case (pie::hac::kc::SystemCallId_GetThreadId):
-		ss << "GetThreadId";
+		str = "GetThreadId";
 		break;
 	case (pie::hac::kc::SystemCallId_Break):
-		ss << "Break";
+		str = "Break";
 		break;
 	case (pie::hac::kc::SystemCallId_OutputDebugString):
-		ss << "OutputDebugString";
+		str = "OutputDebugString";
 		break;
 	case (pie::hac::kc::SystemCallId_ReturnFromException):
-		ss << "ReturnFromException";
+		str = "ReturnFromException";
 		break;
 	case (pie::hac::kc::SystemCallId_GetInfo):
-		ss << "GetInfo";
+		str = "GetInfo";
 		break;
 	case (pie::hac::kc::SystemCallId_FlushEntireDataCache):
-		ss << "FlushEntireDataCache";
+		str = "FlushEntireDataCache";
 		break;
 	case (pie::hac::kc::SystemCallId_FlushDataCache):
-		ss << "FlushDataCache";
+		str = "FlushDataCache";
 		break;
 	case (pie::hac::kc::SystemCallId_MapPhysicalMemory):
-		ss << "MapPhysicalMemory";
+		str = "MapPhysicalMemory";
 		break;
 	case (pie::hac::kc::SystemCallId_UnmapPhysicalMemory):
-		ss << "UnmapPhysicalMemory";
+		str = "UnmapPhysicalMemory";
 		break;
 	case (pie::hac::kc::SystemCallId_GetDebugFutureThreadInfo):
-		ss << "GetDebugFutureThreadInfo";
+		str = "GetDebugFutureThreadInfo";
 		break;
 	case (pie::hac::kc::SystemCallId_GetLastThreadInfo):
-		ss << "GetLastThreadInfo";
+		str = "GetLastThreadInfo";
 		break;
 	case (pie::hac::kc::SystemCallId_GetResourceLimitLimitValue):
-		ss << "GetResourceLimitLimitValue";
+		str = "GetResourceLimitLimitValue";
 		break;
 	case (pie::hac::kc::SystemCallId_GetResourceLimitCurrentValue):
-		ss << "GetResourceLimitCurrentValue";
+		str = "GetResourceLimitCurrentValue";
 		break;
 	case (pie::hac::kc::SystemCallId_SetThreadActivity):
-		ss << "SetThreadActivity";
+		str = "SetThreadActivity";
 		break;
 	case (pie::hac::kc::SystemCallId_GetThreadContext3):
-		ss << "GetThreadContext3";
+		str = "GetThreadContext3";
 		break;
 	case (pie::hac::kc::SystemCallId_WaitForAddress):
-		ss << "WaitForAddress";
+		str = "WaitForAddress";
 		break;
 	case (pie::hac::kc::SystemCallId_SignalToAddress):
-		ss << "SignalToAddress";
+		str = "SignalToAddress";
 		break;
 	case (pie::hac::kc::SystemCallId_SynchronizePreemptionState):
-		ss << "SynchronizePreemptionState";
+		str = "SynchronizePreemptionState";
 		break;
 	case (pie::hac::kc::SystemCallId_Unknown55):
-		ss << "Unknown55";
+		str = "Unknown55";
 		break;
 	case (pie::hac::kc::SystemCallId_Unknown56):
-		ss << "Unknown56";
+		str = "Unknown56";
 		break;
 	case (pie::hac::kc::SystemCallId_Unknown57):
-		ss << "Unknown57";
+		str = "Unknown57";
 		break;
 	case (pie::hac::kc::SystemCallId_Unknown58):
-		ss << "Unknown58";
+		str = "Unknown58";
 		break;
 	case (pie::hac::kc::SystemCallId_Unknown59):
-		ss << "Unknown59";
+		str = "Unknown59";
 		break;
 	case (pie::hac::kc::SystemCallId_KernelDebug):
-		ss << "KernelDebug";
+		str = "KernelDebug";
 		break;
 	case (pie::hac::kc::SystemCallId_ChangeKernelTraceState):
-		ss << "ChangeKernelTraceState";
+		str = "ChangeKernelTraceState";
 		break;
 	case (pie::hac::kc::SystemCallId_Unknown62):
-		ss << "Unknown62";
+		str = "Unknown62";
 		break;
 	case (pie::hac::kc::SystemCallId_Unknown63):
-		ss << "Unknown63";
+		str = "Unknown63";
 		break;
 	case (pie::hac::kc::SystemCallId_CreateSession):
-		ss << "CreateSession";
+		str = "CreateSession";
 		break;
 	case (pie::hac::kc::SystemCallId_AcceptSession):
-		ss << "AcceptSession";
+		str = "AcceptSession";
 		break;
 	case (pie::hac::kc::SystemCallId_ReplyAndReceiveLight):
-		ss << "ReplyAndReceiveLight";
+		str = "ReplyAndReceiveLight";
 		break;
 	case (pie::hac::kc::SystemCallId_ReplyAndReceive):
-		ss << "ReplyAndReceive";
+		str = "ReplyAndReceive";
 		break;
 	case (pie::hac::kc::SystemCallId_ReplyAndReceiveWithUserBuffer):
-		ss << "ReplyAndReceiveWithUserBuffer";
+		str = "ReplyAndReceiveWithUserBuffer";
 		break;
 	case (pie::hac::kc::SystemCallId_CreateEvent):
-		ss << "CreateEvent";
+		str = "CreateEvent";
 		break;
 	case (pie::hac::kc::SystemCallId_Unknown70):
-		ss << "Unknown70";
+		str = "Unknown70";
 		break;
 	case (pie::hac::kc::SystemCallId_Unknown71):
-		ss << "Unknown71";
+		str = "Unknown71";
 		break;
 	case (pie::hac::kc::SystemCallId_MapPhysicalMemoryUnsafe):
-		ss << "MapPhysicalMemoryUnsafe";
+		str = "MapPhysicalMemoryUnsafe";
 		break;
 	case (pie::hac::kc::SystemCallId_UnmapPhysicalMemoryUnsafe):
-		ss << "UnmapPhysicalMemoryUnsafe";
+		str = "UnmapPhysicalMemoryUnsafe";
 		break;
 	case (pie::hac::kc::SystemCallId_SetUnsafeLimit):
-		ss << "SetUnsafeLimit";
+		str = "SetUnsafeLimit";
 		break;
 	case (pie::hac::kc::SystemCallId_CreateCodeMemory):
-		ss << "CreateCodeMemory";
+		str = "CreateCodeMemory";
 		break;
 	case (pie::hac::kc::SystemCallId_ControlCodeMemory):
-		ss << "ControlCodeMemory";
+		str = "ControlCodeMemory";
 		break;
 	case (pie::hac::kc::SystemCallId_SleepSystem):
-		ss << "SleepSystem";
+		str = "SleepSystem";
 		break;
 	case (pie::hac::kc::SystemCallId_ReadWriteRegister):
-		ss << "ReadWriteRegister";
+		str = "ReadWriteRegister";
 		break;
 	case (pie::hac::kc::SystemCallId_SetProcessActivity):
-		ss << "SetProcessActivity";
+		str = "SetProcessActivity";
 		break;
 	case (pie::hac::kc::SystemCallId_CreateSharedMemory):
-		ss << "CreateSharedMemory";
+		str = "CreateSharedMemory";
 		break;
 	case (pie::hac::kc::SystemCallId_MapTransferMemory):
-		ss << "MapTransferMemory";
+		str = "MapTransferMemory";
 		break;
 	case (pie::hac::kc::SystemCallId_UnmapTransferMemory):
-		ss << "UnmapTransferMemory";
+		str = "UnmapTransferMemory";
 		break;
 	case (pie::hac::kc::SystemCallId_CreateInterruptEvent):
-		ss << "CreateInterruptEvent";
+		str = "CreateInterruptEvent";
 		break;
 	case (pie::hac::kc::SystemCallId_QueryPhysicalAddress):
-		ss << "QueryPhysicalAddress";
+		str = "QueryPhysicalAddress";
 		break;
 	case (pie::hac::kc::SystemCallId_QueryIoMapping):
-		ss << "QueryIoMapping";
+		str = "QueryIoMapping";
 		break;
 	case (pie::hac::kc::SystemCallId_CreateDeviceAddressSpace):
-		ss << "CreateDeviceAddressSpace";
+		str = "CreateDeviceAddressSpace";
 		break;
 	case (pie::hac::kc::SystemCallId_AttachDeviceAddressSpace):
-		ss << "AttachDeviceAddressSpace";
+		str = "AttachDeviceAddressSpace";
 		break;
 	case (pie::hac::kc::SystemCallId_DetachDeviceAddressSpace):
-		ss << "DetachDeviceAddressSpace";
+		str = "DetachDeviceAddressSpace";
 		break;
 	case (pie::hac::kc::SystemCallId_MapDeviceAddressSpaceByForce):
-		ss << "MapDeviceAddressSpaceByForce";
+		str = "MapDeviceAddressSpaceByForce";
 		break;
 	case (pie::hac::kc::SystemCallId_MapDeviceAddressSpaceAligned):
-		ss << "MapDeviceAddressSpaceAligned";
+		str = "MapDeviceAddressSpaceAligned";
 		break;
 	case (pie::hac::kc::SystemCallId_MapDeviceAddressSpace):
-		ss << "MapDeviceAddressSpace";
+		str = "MapDeviceAddressSpace";
 		break;
 	case (pie::hac::kc::SystemCallId_UnmapDeviceAddressSpace):
-		ss << "UnmapDeviceAddressSpace";
+		str = "UnmapDeviceAddressSpace";
 		break;
 	case (pie::hac::kc::SystemCallId_InvalidateProcessDataCache):
-		ss << "InvalidateProcessDataCache";
+		str = "InvalidateProcessDataCache";
 		break;
 	case (pie::hac::kc::SystemCallId_StoreProcessDataCache):
-		ss << "StoreProcessDataCache";
+		str = "StoreProcessDataCache";
 		break;
 	case (pie::hac::kc::SystemCallId_FlushProcessDataCache):
-		ss << "FlushProcessDataCache";
+		str = "FlushProcessDataCache";
 		break;
 	case (pie::hac::kc::SystemCallId_DebugActiveProcess):
-		ss << "DebugActiveProcess";
+		str = "DebugActiveProcess";
 		break;
 	case (pie::hac::kc::SystemCallId_BreakDebugProcess):
-		ss << "BreakDebugProcess";
+		str = "BreakDebugProcess";
 		break;
 	case (pie::hac::kc::SystemCallId_TerminateDebugProcess):
-		ss << "TerminateDebugProcess";
+		str = "TerminateDebugProcess";
 		break;
 	case (pie::hac::kc::SystemCallId_GetDebugEvent):
-		ss << "GetDebugEvent";
+		str = "GetDebugEvent";
 		break;
 	case (pie::hac::kc::SystemCallId_ContinueDebugEvent):
-		ss << "ContinueDebugEvent";
+		str = "ContinueDebugEvent";
 		break;
 	case (pie::hac::kc::SystemCallId_GetProcessList):
-		ss << "GetProcessList";
+		str = "GetProcessList";
 		break;
 	case (pie::hac::kc::SystemCallId_GetThreadList):
-		ss << "GetThreadList";
+		str = "GetThreadList";
 		break;
 	case (pie::hac::kc::SystemCallId_GetDebugThreadContext):
-		ss << "GetDebugThreadContext";
+		str = "GetDebugThreadContext";
 		break;
 	case (pie::hac::kc::SystemCallId_SetDebugThreadContext):
-		ss << "SetDebugThreadContext";
+		str = "SetDebugThreadContext";
 		break;
 	case (pie::hac::kc::SystemCallId_QueryDebugProcessMemory):
-		ss << "QueryDebugProcessMemory";
+		str = "QueryDebugProcessMemory";
 		break;
 	case (pie::hac::kc::SystemCallId_ReadDebugProcessMemory):
-		ss << "ReadDebugProcessMemory";
+		str = "ReadDebugProcessMemory";
 		break;
 	case (pie::hac::kc::SystemCallId_WriteDebugProcessMemory):
-		ss << "WriteDebugProcessMemory";
+		str = "WriteDebugProcessMemory";
 		break;
 	case (pie::hac::kc::SystemCallId_SetHardwareBreakPoint):
-		ss << "SetHardwareBreakPoint";
+		str = "SetHardwareBreakPoint";
 		break;
 	case (pie::hac::kc::SystemCallId_GetDebugThreadParam):
-		ss << "GetDebugThreadParam";
+		str = "GetDebugThreadParam";
 		break;
 	case (pie::hac::kc::SystemCallId_Unknown110):
-		ss << "Unknown110";
+		str = "Unknown110";
 		break;
 	case (pie::hac::kc::SystemCallId_GetSystemInfo):
-		ss << "GetSystemInfo";
+		str = "GetSystemInfo";
 		break;
 	case (pie::hac::kc::SystemCallId_CreatePort):
-		ss << "CreatePort";
+		str = "CreatePort";
 		break;
 	case (pie::hac::kc::SystemCallId_ManageNamedPort):
-		ss << "ManageNamedPort";
+		str = "ManageNamedPort";
 		break;
 	case (pie::hac::kc::SystemCallId_ConnectToPort):
-		ss << "ConnectToPort";
+		str = "ConnectToPort";
 		break;
 	case (pie::hac::kc::SystemCallId_SetProcessMemoryPermission):
-		ss << "SetProcessMemoryPermission";
+		str = "SetProcessMemoryPermission";
 		break;
 	case (pie::hac::kc::SystemCallId_MapProcessMemory):
-		ss << "MapProcessMemory";
+		str = "MapProcessMemory";
 		break;
 	case (pie::hac::kc::SystemCallId_UnmapProcessMemory):
-		ss << "UnmapProcessMemory";
+		str = "UnmapProcessMemory";
 		break;
 	case (pie::hac::kc::SystemCallId_QueryProcessMemory):
-		ss << "QueryProcessMemory";
+		str = "QueryProcessMemory";
 		break;
 	case (pie::hac::kc::SystemCallId_MapProcessCodeMemory):
-		ss << "MapProcessCodeMemory";
+		str = "MapProcessCodeMemory";
 		break;
 	case (pie::hac::kc::SystemCallId_UnmapProcessCodeMemory):
-		ss << "UnmapProcessCodeMemory";
+		str = "UnmapProcessCodeMemory";
 		break;
 	case (pie::hac::kc::SystemCallId_CreateProcess):
-		ss << "CreateProcess";
+		str = "CreateProcess";
 		break;
 	case (pie::hac::kc::SystemCallId_StartProcess):
-		ss << "StartProcess";
+		str = "StartProcess";
 		break;
 	case (pie::hac::kc::SystemCallId_TerminateProcess):
-		ss << "TerminateProcess";
+		str = "TerminateProcess";
 		break;
 	case (pie::hac::kc::SystemCallId_GetProcessInfo):
-		ss << "GetProcessInfo";
+		str = "GetProcessInfo";
 		break;
 	case (pie::hac::kc::SystemCallId_CreateResourceLimit):
-		ss << "CreateResourceLimit";
+		str = "CreateResourceLimit";
 		break;
 	case (pie::hac::kc::SystemCallId_SetResourceLimitLimitValue):
-		ss << "SetResourceLimitLimitValue";
+		str = "SetResourceLimitLimitValue";
 		break;
 	case (pie::hac::kc::SystemCallId_CallSecureMonitor):
-		ss << "CallSecureMonitor";
+		str = "CallSecureMonitor";
 		break;
 	default:
-		ss << "syscall_id_" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)syscall_id;
+		str = fmt::format("syscall_id_{:02x}", (uint32_t)syscall_id);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }

--- a/src/hac/MetaUtil.cpp
+++ b/src/hac/MetaUtil.cpp
@@ -1,29 +1,28 @@
 #include <pietendo/hac/MetaUtil.h>
-#include <sstream>
-#include <iomanip>
+#include <fmt/format.h>
 
 std::string pie::hac::MetaUtil::getProcessAddressSpaceAsString(pie::hac::meta::ProcessAddressSpace type)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch(type)
 	{
 	case (pie::hac::meta::ProcessAddressSpace_32Bit):
-		ss << "AddressSpace32Bit";
+		str = "AddressSpace32Bit";
 		break;
 	case (pie::hac::meta::ProcessAddressSpace_64BitOld):
-		ss << "AddressSpace64BitOld";
+		str = "AddressSpace64BitOld";
 		break;
 	case (pie::hac::meta::ProcessAddressSpace_32BitNoReserved):
-		ss << "AddressSpace32BitNoReserved";
+		str = "AddressSpace32BitNoReserved";
 		break;
 	case (pie::hac::meta::ProcessAddressSpace_64Bit):
-		ss << "AddressSpace64Bit";
+		str = "AddressSpace64Bit";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)type;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)type);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }

--- a/src/hac/NrrUtil.cpp
+++ b/src/hac/NrrUtil.cpp
@@ -1,23 +1,22 @@
 #include <pietendo/hac/NrrUtil.h>
-#include <sstream>
-#include <iomanip>
+#include <fmt/format.h>
 
 std::string pie::hac::NrrUtil::getNrrKindAsString(pie::hac::nrr::NrrKind val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::nrr::NrrKind_User):
-		ss << "User";
+		str = "User";
 		break;
 	case (pie::hac::nrr::NrrKind_JitPlugin):
-		ss << "JitPlugin";
+		str = "JitPlugin";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }

--- a/src/hac/PartitionFsUtil.cpp
+++ b/src/hac/PartitionFsUtil.cpp
@@ -1,43 +1,42 @@
 #include <pietendo/hac/PartitionFsUtil.h>
-#include <sstream>
-#include <iomanip>
+#include <fmt/format.h>
 
 std::string pie::hac::PartitionFsUtil::getFsTypeAsString(pie::hac::PartitionFsHeader::FsType val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::PartitionFsHeader::TYPE_PFS0):
-		ss << "PFS0";
+		str = "PFS0";
 		break;
 	case (pie::hac::PartitionFsHeader::TYPE_HFS0):
-		ss << "HFS0";
+		str = "HFS0";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }
 
 std::string pie::hac::PartitionFsUtil::getFsTypeAsStringDescription(pie::hac::PartitionFsHeader::FsType val)
 {
-	std::stringstream ss;
+	std::string str;
 
 	switch (val)
 	{
 	case (pie::hac::PartitionFsHeader::TYPE_PFS0):
-		ss << "Partition FileSystem";
+		str = "Partition FileSystem";
 		break;
 	case (pie::hac::PartitionFsHeader::TYPE_HFS0):
-		ss << "Hashed Partition FileSystem";
+		str = "Hashed Partition FileSystem";
 		break;
 	default:
-		ss << "unk_0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)val;
+		str = fmt::format("unk_0x{:02x}", (uint32_t)val);
 		break;
 	}
 
-	return ss.str();
+	return str;
 }


### PR DESCRIPTION
# About
This release bring a bug fix and some internal changes.

# Changes
## Additions
N/A
## Changes
* Replaces `struct pie::hac::sGcPage` with `pie::hac::gc::gc_page_t`, since the struct was being used to hold a single array.
## Bug fixes
* Fixes an issue in `pie::hac::ApplicationControlPropertyUtil::getLanguageAsString()` where enum `Language_BrazilianPortuguese` was not handled properly.
